### PR TITLE
Enable to set TERM by using new property setenvTERM

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -100,8 +100,6 @@ void parse_args(int argc, char* argv[], QString& workdir, QString & shell_comman
 
 int main(int argc, char *argv[])
 {
-    setenv("TERM", "xterm", 1); // TODO/FIXME: why?
-
     QApplication::setApplicationName("qterminal");
     QApplication::setApplicationVersion(STR_VERSION);
     QApplication::setOrganizationDomain("qterminal.org");

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -68,14 +68,11 @@ void Properties::loadSettings()
 
     //setenv "TERM". If setenvTERM is empty, set it to xterm.
     setenvTERM = m_settings->value("setenvTERM", QString()).toString();
-    // Convert QString to const char* for setenvTERM.
-    QByteArray setenvTERMBA = setenvTERM.toUtf8();
-    const char *setenvTERMChar = setenvTERMBA.data();
     if (setenvTERM.isEmpty())
         setenv("TERM", "xterm", 1);
     else
-        setenv("TERM", setenvTERMChar, 1);
-    
+        setenv("TERM", setenvTERM.toUtf8().data(), 1);
+   
     colorScheme = m_settings->value("colorScheme", "Linux").toString();
 
     highlightCurrentTerminal = m_settings->value("highlightCurrentTerminal", true).toBool();

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -66,6 +66,16 @@ void Properties::loadSettings()
     if (!guiStyle.isNull())
         QApplication::setStyle(guiStyle);
 
+    //setenv "TERM". If setenvTERM is empty, set it to xterm.
+    setenvTERM = m_settings->value("setenvTERM", QString()).toString();
+    // Convert QString to const char* for setenvTERM.
+    QByteArray setenvTERMBA = setenvTERM.toUtf8();
+    const char *setenvTERMChar = setenvTERMBA.data();
+    if (setenvTERM.isEmpty())
+        setenv("TERM", "xterm", 1);
+    else
+        setenv("TERM", setenvTERMChar, 1);
+    
     colorScheme = m_settings->value("colorScheme", "Linux").toString();
 
     highlightCurrentTerminal = m_settings->value("highlightCurrentTerminal", true).toBool();
@@ -141,6 +151,7 @@ void Properties::loadSettings()
 void Properties::saveSettings()
 {
     m_settings->setValue("guiStyle", guiStyle);
+    m_settings->setValue("setenvTERM", setenvTERM);
     m_settings->setValue("colorScheme", colorScheme);
     m_settings->setValue("highlightCurrentTerminal", highlightCurrentTerminal);
     m_settings->setValue("font", font);

--- a/src/properties.h
+++ b/src/properties.h
@@ -49,7 +49,7 @@ class Properties
         QFont font;
         QString colorScheme;
         QString guiStyle;
-	QString setenvTERM;
+       	QString setenvTERM;
         bool highlightCurrentTerminal;
 
         bool historyLimited;

--- a/src/properties.h
+++ b/src/properties.h
@@ -49,7 +49,7 @@ class Properties
         QFont font;
         QString colorScheme;
         QString guiStyle;
-       	QString setenvTERM;
+        QString setenvTERM;
         bool highlightCurrentTerminal;
 
         bool historyLimited;

--- a/src/properties.h
+++ b/src/properties.h
@@ -49,6 +49,7 @@ class Properties
         QFont font;
         QString colorScheme;
         QString guiStyle;
+	QString setenvTERM;
         bool highlightCurrentTerminal;
 
         bool historyLimited;


### PR DESCRIPTION
In current status, qterminal sets environment variable TERM to xterm. However, I sometimes want to use xterm-256color when I use Vim with color scheme (related issue #100).
My suggestion is addition a new property _setenvTERM_ which can be set by editing in configuration file (`~/.config/qterminal.org/qterminal.ini`).

When the commited program is executed , a line for property _setenvTERM_ is automatically added in `qterminal.ini`. 

If user want to change TERM, edit this line in the file and restart.
For example, in the case using xterm-256color, edit the line in `qterminal.ini` as following:
`setenvTERM=xterm-256color`
