### PR TITLE
Fix segfault when collapsing subterminals

### DIFF
--- a/src/termwidgetholder.cpp
+++ b/src/termwidgetholder.cpp
@@ -205,6 +205,7 @@ void TermWidgetHolder::splitCollapse(TermWidget * term)
     {
         parent->setParent(0);
         delete parent;
+        parent = Q_NULLPTR;
     }
 
     QList<TermWidget*> tlist = findChildren<TermWidget *>();


### PR DESCRIPTION
Looks like it's just trying to access a deleted object... Fix for #212 