### PR TITLE
Fix context menu actions being applied to the window opened last

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -94,6 +94,7 @@ MainWindow::MainWindow(const QString& work_dir,
     setup_FileMenu_Actions();
     setup_ActionsMenu_Actions();
     setup_ViewMenu_Actions();
+    setup_ContextMenu_Actions();
     setupCustomDirs();
 
     /* The tab should be added after all changes are made to
@@ -506,6 +507,26 @@ void MainWindow::setup_ViewMenu_Actions()
     }
 
     menu_Window->addMenu(keyboardCursorShapeMenu);
+}
+
+void MainWindow::setup_ContextMenu_Actions()
+{
+    m_contextMenu = new QMenu(this);
+    m_contextMenu->addAction(Properties::Instance()->actions[COPY_SELECTION]);
+    m_contextMenu->addAction(Properties::Instance()->actions[PASTE_CLIPBOARD]);
+    m_contextMenu->addAction(Properties::Instance()->actions[PASTE_SELECTION]);
+    m_contextMenu->addAction(Properties::Instance()->actions[ZOOM_IN]);
+    m_contextMenu->addAction(Properties::Instance()->actions[ZOOM_OUT]);
+    m_contextMenu->addAction(Properties::Instance()->actions[ZOOM_RESET]);
+    m_contextMenu->addSeparator();
+    m_contextMenu->addAction(Properties::Instance()->actions[CLEAR_TERMINAL]);
+    m_contextMenu->addAction(Properties::Instance()->actions[SPLIT_HORIZONTAL]);
+    m_contextMenu->addAction(Properties::Instance()->actions[SPLIT_VERTICAL]);
+    #warning TODO/FIXME: disable the action when there is only one terminal
+    m_contextMenu->addAction(Properties::Instance()->actions[SUB_COLLAPSE]);
+    m_contextMenu->addSeparator();
+    m_contextMenu->addAction(Properties::Instance()->actions[TOGGLE_MENU]);
+    m_contextMenu->addAction(Properties::Instance()->actions[PREFERENCES]);
 }
 
 void MainWindow::setupCustomDirs()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -36,7 +36,8 @@ public:
                QWidget * parent = 0, Qt::WindowFlags f = 0);
     ~MainWindow();
 
-    bool dropMode() { return m_dropMode; }
+    bool dropMode() const { return m_dropMode; }
+    QMenu *getContextMenu() const { return m_contextMenu; }
 
 protected:
      bool event(QEvent* event);
@@ -49,10 +50,12 @@ private:
     QString m_initShell;
 
     QDockWidget *m_bookmarksDock;
+    QMenu * m_contextMenu;
 
     void setup_FileMenu_Actions();
     void setup_ActionsMenu_Actions();
     void setup_ViewMenu_Actions();
+    void setup_ContextMenu_Actions();
     void setupCustomDirs();
 
     void closeEvent(QCloseEvent*);

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -24,6 +24,7 @@
 #include "termwidget.h"
 #include "config.h"
 #include "properties.h"
+#include "mainwindow.h"
 
 static int TermWidgetCount = 0;
 
@@ -123,23 +124,8 @@ void TermWidgetImpl::propertiesChanged()
 
 void TermWidgetImpl::customContextMenuCall(const QPoint & pos)
 {
-    QMenu menu;
-    menu.addAction(Properties::Instance()->actions[COPY_SELECTION]);
-    menu.addAction(Properties::Instance()->actions[PASTE_CLIPBOARD]);
-    menu.addAction(Properties::Instance()->actions[PASTE_SELECTION]);
-    menu.addAction(Properties::Instance()->actions[ZOOM_IN]);
-    menu.addAction(Properties::Instance()->actions[ZOOM_OUT]);
-    menu.addAction(Properties::Instance()->actions[ZOOM_RESET]);
-    menu.addSeparator();
-    menu.addAction(Properties::Instance()->actions[CLEAR_TERMINAL]);
-    menu.addAction(Properties::Instance()->actions[SPLIT_HORIZONTAL]);
-    menu.addAction(Properties::Instance()->actions[SPLIT_VERTICAL]);
-#warning TODO/FIXME: disable the action when there is only one terminal
-    menu.addAction(Properties::Instance()->actions[SUB_COLLAPSE]);
-    menu.addSeparator();
-    menu.addAction(Properties::Instance()->actions[TOGGLE_MENU]);
-    menu.addAction(Properties::Instance()->actions[PREFERENCES]);
-    menu.exec(mapToGlobal(pos));
+    const MainWindow *main = qobject_cast<MainWindow*>(window());
+    main->getContextMenu()->exec(mapToGlobal(pos));
 }
 
 void TermWidgetImpl::zoomIn()


### PR DESCRIPTION
The problem is that the static actions stored within the `Properties` instance object get overwritten when a new terminal window is created which leads to them being applied to that last window.

Fixes #126 