### PR TITLE
Delete Properties instance on exit

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -149,6 +149,7 @@ int main(int argc, char *argv[])
     }
 
     int ret = app.exec();
+    delete Properties::Instance();
     delete window;
 
     return ret;

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -46,8 +46,7 @@ Properties::~Properties()
 {
     qDebug("Properties destructor called");
     saveSettings();
-    m_settings->deleteLater();
-    delete m_instance;
+    delete m_settings;
     m_instance = 0;
 }
 

--- a/src/properties.h
+++ b/src/properties.h
@@ -35,6 +35,7 @@ class Properties
 {
     public:
         static Properties *Instance(const QString& filename = QString());
+        ~Properties();
 
         QFont defaultFont();
         void saveSettings();
@@ -102,7 +103,6 @@ class Properties
 
         explicit Properties(const QString& filename);
         Properties(const Properties &) {};
-        ~Properties();
 
         QSettings *m_settings;
 


### PR DESCRIPTION
Fixes some memory leaks like the following:
```
==11875== 240 bytes in 1 blocks are still reachable in loss record 6,610 of 7,112
==11875==    at 0x4C2B0D8: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==11875==    by 0x6A11A6C: ??? (in /usr/lib/libQt5Core.so.5.6.0)
==11875==    by 0x6A11BD5: QSettings::QSettings(QObject*) (in /usr/lib/libQt5Core.so.5.6.0)
==11875==    by 0x4426F6: Properties::Properties(QString const&) (in /home/frtb38/qterminal/qterminal)
==11875==    by 0x4425BE: Properties::Instance(QString const&) (in /home/frtb38/qterminal/qterminal)
==11875==    by 0x41ED19: MainWindow::MainWindow(QString const&, QString const&, bool, QWidget*, QFlags<Qt::WindowType>) (in /home/frtb38/qterminal/qterminal)
==11875==    by 0x41E6C0: main (in /home/frtb38/qterminal/qterminal)

==11875== 192 bytes in 1 blocks are still reachable in loss record 6,550 of 7,112
==11875==    at 0x4C2B0D8: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==11875==    by 0x4425B0: Properties::Instance(QString const&) (in /home/frtb38/qterminal/qterminal)
==11875==    by 0x41ED19: MainWindow::MainWindow(QString const&, QString const&, bool, QWidget*, QFlags<Qt::WindowType>) (in /home/frtb38/qterminal/qterminal)
==11875==    by 0x41E6C0: main (in /home/frtb38/qterminal/qterminal)
```