### PR TITLE
Fix compilation warning related to QXmlStreamReader

### DIFF
--- a/src/bookmarkswidget.cpp
+++ b/src/bookmarkswidget.cpp
@@ -221,10 +221,10 @@ public:
                          << xml.lineNumber() << xml.columnNumber();
                 m_map.clear();
                 return;
-                break;
             case QXmlStreamReader::EndDocument:
                 m_map.clear();
                 return;
+            default:
                 break;
             } // switch
         } // while


### PR DESCRIPTION
Also remove unneeded `break` statements.
Fixes #241 