### PR TITLE
Set the desktopFileName property

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -105,6 +105,9 @@ int main(int argc, char *argv[])
     QApplication::setApplicationName("qterminal");
     QApplication::setApplicationVersion(STR_VERSION);
     QApplication::setOrganizationDomain("qterminal.org");
+#if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
+    QApplication::setDesktopFileName(QLatin1String("qterminal.desktop"));
+#endif
     // Warning: do not change settings format. It can screw bookmarks later.
     QSettings::setDefaultFormat(QSettings::IniFormat);
 


### PR DESCRIPTION
Qt 5.7 introduced a property that applications must use in order
to let window managers know exactly where is the desktop entry.

This will let task managers show precise information.