### PR TITLE
Handle title changing ASCII escape sequences

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -745,7 +745,7 @@ void MainWindow::addNewTab()
 
 void MainWindow::windowTitleChanged()
 {
-    QString userTitle = consoleTabulator->title();
+    const QString& userTitle = consoleTabulator->title();
     if (!userTitle.isNull())
     {
         setWindowTitle(userTitle);
@@ -754,7 +754,7 @@ void MainWindow::windowTitleChanged()
 
 void MainWindow::tabChanged()
 {
-    QString userTitle = consoleTabulator->title();
+    const QString& userTitle = consoleTabulator->title();
     if (!userTitle.isNull())
     {
         setWindowTitle(userTitle);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -84,8 +84,8 @@ MainWindow::MainWindow(const QString& work_dir,
 
     consoleTabulator->setAutoFillBackground(true);
     connect(consoleTabulator, SIGNAL(closeTabNotification()), SLOT(close()));
-    connect(consoleTabulator, SIGNAL(titleChanged(QString, QString)),
-            this, SLOT(windowTitleChanged(QString, QString)));
+    connect(consoleTabulator, SIGNAL(titleChanged()), this, SLOT(windowTitleChanged()));
+    connect(consoleTabulator, SIGNAL(tabChanged()), this, SLOT(tabChanged()));
     consoleTabulator->setWorkDirectory(work_dir);
     consoleTabulator->setTabPosition((QTabWidget::TabPosition)Properties::Instance()->tabsPos);
     //consoleTabulator->setShellProgram(command);
@@ -743,8 +743,18 @@ void MainWindow::addNewTab()
         consoleTabulator->addNewTab();
 }
 
-void MainWindow::windowTitleChanged(QString userTitle, QString iconText)
+void MainWindow::windowTitleChanged()
 {
+    QString userTitle = consoleTabulator->title();
+    if (!userTitle.isNull())
+    {
+        setWindowTitle(userTitle);
+    }
+}
+
+void MainWindow::tabChanged()
+{
+    QString userTitle = consoleTabulator->title();
     if (!userTitle.isNull())
     {
         setWindowTitle(userTitle);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -84,6 +84,8 @@ MainWindow::MainWindow(const QString& work_dir,
 
     consoleTabulator->setAutoFillBackground(true);
     connect(consoleTabulator, SIGNAL(closeTabNotification()), SLOT(close()));
+    connect(consoleTabulator, SIGNAL(titleChanged(QString, QString)),
+            this, SLOT(windowTitleChanged(QString, QString)));
     consoleTabulator->setWorkDirectory(work_dir);
     consoleTabulator->setTabPosition((QTabWidget::TabPosition)Properties::Instance()->tabsPos);
     //consoleTabulator->setShellProgram(command);
@@ -739,4 +741,12 @@ void MainWindow::addNewTab()
         consoleTabulator->preset2Horizontal();
     else
         consoleTabulator->addNewTab();
+}
+
+void MainWindow::windowTitleChanged(QString userTitle, QString iconText)
+{
+    if (!userTitle.isNull())
+    {
+        setWindowTitle(userTitle);
+    }
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -85,6 +85,7 @@ private slots:
     void bookmarksDock_visibilityChanged(bool visible);
 
     void addNewTab();
-    void windowTitleChanged(QString userTitle, QString iconText);
+    void windowTitleChanged();
+    void tabChanged();
 };
 #endif //MAINWINDOW_H

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -85,5 +85,6 @@ private slots:
     void bookmarksDock_visibilityChanged(bool visible);
 
     void addNewTab();
+    void windowTitleChanged(QString userTitle, QString iconText);
 };
 #endif //MAINWINDOW_H

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -217,7 +217,7 @@ bool TabWidget::eventFilter(QObject *obj, QEvent *event)
 }
 
 /* static */
-int TabWidget::tabIndex(QObject * term)
+int TabWidget::tabIndex(const QObject * term)
 {
     QVariant prop = term->property(TAB_INDEX_PROPERTY);
     if(prop.isValid() && prop.canConvert(QVariant::Int))
@@ -241,7 +241,7 @@ void TabWidget::removeFinished()
 
 void TabWidget::termTitleChanged(TermWidgetHolder * term)
 {
-    QString userTitle = term->title();
+    const QString& userTitle = term->title();
     if (!userTitle.isNull())
     {
         int index = tabIndex(term);

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -53,7 +53,7 @@ TabWidget::TabWidget(QWidget* parent) : QTabWidget(parent), tabNumerator(0)
     connect(this, SIGNAL(tabRenameRequested(int)), this, SLOT(renameSession(int)));
 }
 
-TermWidgetHolder * TabWidget::terminalHolder()
+TermWidgetHolder * TabWidget::terminalHolder() const
 {
     return reinterpret_cast<TermWidgetHolder*>(widget(currentIndex()));
 }
@@ -80,8 +80,8 @@ int TabWidget::addNewTab(const QString & shell_program)
     TermWidgetHolder *console = new TermWidgetHolder(cwd, shell_program, this);
     connect(console, SIGNAL(finished()), SLOT(removeFinished()));
     connect(console, SIGNAL(lastTerminalClosed()), this, SLOT(removeFinished()));
-    connect(console, SIGNAL(termTitleChanged(TermWidgetHolder*, QString, QString)),
-            this, SLOT(termTitleChanged(TermWidgetHolder*, QString, QString)));
+    connect(console, SIGNAL(termTitleChanged(TermWidgetHolder*)),
+            this, SLOT(termTitleChanged(TermWidgetHolder*)));
 
     int index = addTab(console, label);
     updateTabIndices();
@@ -216,6 +216,7 @@ bool TabWidget::eventFilter(QObject *obj, QEvent *event)
     return QTabWidget::eventFilter(obj, event);
 }
 
+/* static */
 int TabWidget::tabIndex(QObject * term)
 {
     QVariant prop = term->property(TAB_INDEX_PROPERTY);
@@ -238,8 +239,9 @@ void TabWidget::removeFinished()
     }
 }
 
-void TabWidget::termTitleChanged(TermWidgetHolder * term, QString userTitle, QString iconText)
+void TabWidget::termTitleChanged(TermWidgetHolder * term)
 {
+    QString userTitle = term->title();
     if (!userTitle.isNull())
     {
         int index = tabIndex(term);
@@ -249,7 +251,12 @@ void TabWidget::termTitleChanged(TermWidgetHolder * term, QString userTitle, QSt
         }
     }
 
-    emit titleChanged(userTitle, iconText);
+    emit titleChanged();
+}
+
+QString TabWidget::title() const
+{
+    return terminalHolder()->title();
 }
 
 void TabWidget::removeTab(int index)
@@ -299,6 +306,7 @@ int TabWidget::switchToRight()
         setCurrentIndex(next_pos);
     else
         setCurrentIndex(0);
+    emit tabChanged();
     return currentIndex();
 }
 
@@ -309,6 +317,7 @@ int TabWidget::switchToLeft()
         setCurrentIndex(count() - 1);
     else
         setCurrentIndex(previous_pos);
+    emit tabChanged();
     return currentIndex();
 }
 

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -80,6 +80,8 @@ int TabWidget::addNewTab(const QString & shell_program)
     TermWidgetHolder *console = new TermWidgetHolder(cwd, shell_program, this);
     connect(console, SIGNAL(finished()), SLOT(removeFinished()));
     connect(console, SIGNAL(lastTerminalClosed()), this, SLOT(removeFinished()));
+    connect(console, SIGNAL(termTitleChanged(TermWidgetHolder*, QString, QString)),
+            this, SLOT(termTitleChanged(TermWidgetHolder*, QString, QString)));
 
     int index = addTab(console, label);
     updateTabIndices();
@@ -214,17 +216,40 @@ bool TabWidget::eventFilter(QObject *obj, QEvent *event)
     return QTabWidget::eventFilter(obj, event);
 }
 
-void TabWidget::removeFinished()
+int TabWidget::tabIndex(QObject * term)
 {
-    QObject* term = sender();
     QVariant prop = term->property(TAB_INDEX_PROPERTY);
     if(prop.isValid() && prop.canConvert(QVariant::Int))
     {
-        int index = prop.toInt();
+        return prop.toInt();
+    }
+    return -1;
+}
+
+void TabWidget::removeFinished()
+{
+    QObject* term = sender();
+    int index = tabIndex(term);
+    if (index >= 0)
+    {
         removeTab(index);
 //        if (count() == 0)
 //            emit closeTabNotification();
     }
+}
+
+void TabWidget::termTitleChanged(TermWidgetHolder * term, QString userTitle, QString iconText)
+{
+    if (!userTitle.isNull())
+    {
+        int index = tabIndex(term);
+        if (index >= 0)
+        {
+            setTabText(index, userTitle);
+        }
+    }
+
+    emit titleChanged(userTitle, iconText);
 }
 
 void TabWidget::removeTab(int index)

--- a/src/tabwidget.h
+++ b/src/tabwidget.h
@@ -107,7 +107,7 @@ private:
     QString _customTitle;
     /* re-order naming of the tabs then removeCurrentTab() */
     void renameTabsAfterRemove();
-    static int tabIndex(QObject * term);
+    static int tabIndex(const QObject * term);
 };
 
 #endif

--- a/src/tabwidget.h
+++ b/src/tabwidget.h
@@ -79,9 +79,12 @@ public slots:
     void preset2Vertical();
     void preset4Terminals();
 
+    void termTitleChanged(TermWidgetHolder * term, QString userTitle, QString iconText);
+
 signals:
     void closeTabNotification();
     void tabRenameRequested(int);
+    void titleChanged(QString userTitle, QString iconText);
 
 protected:
     enum Direction{Left = 1, Right};
@@ -101,6 +104,7 @@ private:
     QString work_dir;
     /* re-order naming of the tabs then removeCurrentTab() */
     void renameTabsAfterRemove();
+    int tabIndex(QObject * term);
 };
 
 #endif

--- a/src/tabwidget.h
+++ b/src/tabwidget.h
@@ -35,9 +35,10 @@ Q_OBJECT
 public:
     TabWidget(QWidget* parent = 0);
 
-    TermWidgetHolder * terminalHolder();
+    TermWidgetHolder * terminalHolder() const;
 
     void showHideTabBar();
+    QString title() const;
 
 public slots:
     int addNewTab(const QString& shell_program = QString());
@@ -79,12 +80,13 @@ public slots:
     void preset2Vertical();
     void preset4Terminals();
 
-    void termTitleChanged(TermWidgetHolder * term, QString userTitle, QString iconText);
+    void termTitleChanged(TermWidgetHolder * term);
 
 signals:
     void closeTabNotification();
     void tabRenameRequested(int);
-    void titleChanged(QString userTitle, QString iconText);
+    void titleChanged();
+    void tabChanged();
 
 protected:
     enum Direction{Left = 1, Right};
@@ -102,9 +104,10 @@ protected slots:
 private:
     int tabNumerator;
     QString work_dir;
+    QString _customTitle;
     /* re-order naming of the tabs then removeCurrentTab() */
     void renameTabsAfterRemove();
-    int tabIndex(QObject * term);
+    static int tabIndex(QObject * term);
 };
 
 #endif

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -189,6 +189,7 @@ TermWidget::TermWidget(const QString & wdir, const QString & shell, QWidget * pa
     connect(m_term, SIGNAL(finished()), this, SIGNAL(finished()));
     connect(m_term, SIGNAL(termGetFocus()), this, SLOT(term_termGetFocus()));
     connect(m_term, SIGNAL(termLostFocus()), this, SLOT(term_termLostFocus()));
+    connect(m_term, SIGNAL(titleChanged()), this, SLOT(term_termTitleChanged()));
 }
 
 void TermWidget::propertiesChanged()
@@ -212,6 +213,11 @@ void TermWidget::term_termLostFocus()
 {
     m_border = palette().color(QPalette::Window);
     update();
+}
+
+void TermWidget::term_termTitleChanged()
+{
+    emit termTitleChanged(this);
 }
 
 void TermWidget::paintEvent (QPaintEvent *)

--- a/src/termwidget.h
+++ b/src/termwidget.h
@@ -74,6 +74,7 @@ class TermWidget : public QWidget
         void splitVertical(TermWidget * self);
         void splitCollapse(TermWidget * self);
         void termGetFocus(TermWidget * self);
+        void termTitleChanged(TermWidget * self);
 
     public slots:
 
@@ -83,6 +84,7 @@ class TermWidget : public QWidget
     private slots:
         void term_termGetFocus();
         void term_termLostFocus();
+        void term_termTitleChanged();
 };
 
 #endif

--- a/src/termwidgetholder.cpp
+++ b/src/termwidgetholder.cpp
@@ -281,6 +281,8 @@ TermWidget *TermWidgetHolder::newTerm(const QString & wdir, const QString & shel
             this, SLOT(splitCollapse(TermWidget *)));
     connect(w, SIGNAL(termGetFocus(TermWidget *)),
             this, SLOT(setCurrentTerminal(TermWidget *)));
+    connect(w, SIGNAL(termTitleChanged(TermWidget *)),
+            this, SLOT(setTerminalTitle(TermWidget *)));
 
     return w;
 }
@@ -288,6 +290,11 @@ TermWidget *TermWidgetHolder::newTerm(const QString & wdir, const QString & shel
 void TermWidgetHolder::setCurrentTerminal(TermWidget* term)
 {
     m_currentTerm = term;
+}
+
+void TermWidgetHolder::setTerminalTitle(TermWidget* term)
+{
+    emit termTitleChanged(this, term->impl()->userTitle(), term->impl()->iconText());
 }
 
 void TermWidgetHolder::handle_finished()

--- a/src/termwidgetholder.cpp
+++ b/src/termwidgetholder.cpp
@@ -292,9 +292,15 @@ void TermWidgetHolder::setCurrentTerminal(TermWidget* term)
     m_currentTerm = term;
 }
 
+QString TermWidgetHolder::title() const
+{
+    return m_title;
+}
+
 void TermWidgetHolder::setTerminalTitle(TermWidget* term)
 {
-    emit termTitleChanged(this, term->impl()->userTitle(), term->impl()->iconText());
+    m_title = term->impl()->userTitle();
+    emit termTitleChanged(this);
 }
 
 void TermWidgetHolder::handle_finished()

--- a/src/termwidgetholder.h
+++ b/src/termwidgetholder.h
@@ -51,6 +51,8 @@ class TermWidgetHolder : public QWidget
 
         TermWidget* currentTerminal();
 
+        QString title() const;
+
     public slots:
         void splitHorizontal(TermWidget * term);
         void splitVertical(TermWidget * term);
@@ -64,11 +66,12 @@ class TermWidgetHolder : public QWidget
         void finished();
         void lastTerminalClosed();
         void renameSession();
-        void termTitleChanged(TermWidgetHolder * term, QString userTitle, QString iconText);
+        void termTitleChanged(TermWidgetHolder * term);
 
     private:
         QString m_wdir;
         QString m_shell;
+        QString m_title;
         TermWidget * m_currentTerm;
 
         void split(TermWidget * term, Qt::Orientation orientation);

--- a/src/termwidgetholder.h
+++ b/src/termwidgetholder.h
@@ -64,6 +64,7 @@ class TermWidgetHolder : public QWidget
         void finished();
         void lastTerminalClosed();
         void renameSession();
+        void termTitleChanged(TermWidgetHolder * term, QString userTitle, QString iconText);
 
     private:
         QString m_wdir;
@@ -75,6 +76,7 @@ class TermWidgetHolder : public QWidget
 
     private slots:
         void setCurrentTerminal(TermWidget* term);
+        void setTerminalTitle(TermWidget* term);
         void handle_finished();
 };
 


### PR DESCRIPTION
PS. This relies on https://github.com/lxde/qtermwidget/pull/83

I follow the idea proposed by @palinek at https://github.com/lxde/qterminal/issues/52#issuecomment-227962047. That is, handle OSC commands and push changes to tabs and the main window. Suprisingly, OSC parsing functionality is already implemented in qtermwidget. What I do is just connecting signals and slots.

It's my first time writing Qt codes. Sorry if these changes looks naive.