### PR TITLE
Replace numbered terminals with directional navigation

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -37,8 +37,10 @@
 #define SPLIT_VERTICAL "Split Terminal Vertically"
 
 #define SUB_COLLAPSE "Collapse Subterminal"
-#define SUB_NEXT "Next Subterminal"
-#define SUB_PREV "Previous Subterminal"
+#define SUB_LEFT "Left Subterminal"
+#define SUB_RIGHT "Right Subterminal"
+#define SUB_TOP "Top Subterminal"
+#define SUB_BOTTOM "Bottom Subterminal"
 
 #define MOVE_LEFT "Move Tab Left"
 #define MOVE_RIGHT "Move Tab Right"
@@ -69,10 +71,13 @@
 
 // ACTIONS
 #define CLEAR_TERMINAL_SHORTCUT        "Ctrl+Shift+X"
-#define TAB_PREV_SHORTCUT	       "Shift+Left|Ctrl+PgUp|Ctrl+Shift+Tab"
-#define TAB_NEXT_SHORTCUT	       "Shift+Right|Ctrl+PgDown|Ctrl+Tab"
-#define SUB_PREV_SHORTCUT	       "Shift+Down"
-#define SUB_NEXT_SHORTCUT	       "Shift+Up"
+
+#define TAB_PREV_SHORTCUT	       "Ctrl+PgUp|Ctrl+Shift+Tab"
+#define TAB_NEXT_SHORTCUT	       "Ctrl+PgDown|Ctrl+Tab"
+#define SUB_BOTTOM_SHORTCUT	       "Shift+Down"
+#define SUB_TOP_SHORTCUT	       "Shift+Up"
+#define SUB_LEFT_SHORTCUT	       "Shift+Left"
+#define SUB_RIGHT_SHORTCUT	       "Shift+Right"
 
 #ifdef Q_WS_MAC
 // It's tricky - Ctrl is "command" key on mac's keyboards

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -236,11 +236,18 @@ void MainWindow::setup_ActionsMenu_Actions()
     setup_Action(SUB_COLLAPSE, new QAction(tr("&Collapse Subterminal"), settingOwner),
                  NULL, consoleTabulator, SLOT(splitCollapse()), menu_Actions, data);
 
-    setup_Action(SUB_NEXT, new QAction(QIcon::fromTheme("go-up"), tr("N&ext Subterminal"), settingOwner),
-                 SUB_NEXT_SHORTCUT, consoleTabulator, SLOT(switchNextSubterminal()), menu_Actions, data);
+    setup_Action(SUB_TOP, new QAction(QIcon::fromTheme("go-up"), tr("&Top Subterminal"), settingOwner),
+                 SUB_TOP_SHORTCUT, consoleTabulator, SLOT(switchTopSubterminal()), menu_Actions, data);
 
-    setup_Action(SUB_PREV, new QAction(QIcon::fromTheme("go-down"), tr("P&revious Subterminal"), settingOwner),
-                 SUB_PREV_SHORTCUT, consoleTabulator, SLOT(switchPrevSubterminal()), menu_Actions, data);
+    setup_Action(SUB_BOTTOM, new QAction(QIcon::fromTheme("go-down"), tr("&Bottom Subterminal"), settingOwner),
+                 SUB_BOTTOM_SHORTCUT, consoleTabulator, SLOT(switchBottomSubterminal()), menu_Actions, data);
+
+    setup_Action(SUB_LEFT, new QAction(QIcon::fromTheme("go-previous"), tr("L&eft Subterminal"), settingOwner),
+                 SUB_LEFT_SHORTCUT, consoleTabulator, SLOT(switchLeftSubterminal()), menu_Actions, data);
+
+    setup_Action(SUB_RIGHT, new QAction(QIcon::fromTheme("go-next"), tr("R&ight Subterminal"), settingOwner),
+                 SUB_RIGHT_SHORTCUT, consoleTabulator, SLOT(switchRightSubterminal()), menu_Actions, data);
+
 
     menu_Actions->addSeparator();
 

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -89,14 +89,22 @@ int TabWidget::addNewTab(TerminalConfig config)
     return index;
 }
 
-void TabWidget::switchNextSubterminal()
+void TabWidget::switchLeftSubterminal()
 {
-    terminalHolder()->switchNextSubterminal();
+    terminalHolder()->directionalNavigation(NavigationDirection::Left);
 }
 
-void TabWidget::switchPrevSubterminal()
+void TabWidget::switchRightSubterminal()
 {
-    terminalHolder()->switchPrevSubterminal();
+    terminalHolder()->directionalNavigation(NavigationDirection::Right);
+}
+
+void TabWidget::switchTopSubterminal() {
+    terminalHolder()->directionalNavigation(NavigationDirection::Top);
+}
+
+void TabWidget::switchBottomSubterminal() {
+    terminalHolder()->directionalNavigation(NavigationDirection::Bottom);
 }
 
 void TabWidget::splitHorizontally()
@@ -428,7 +436,7 @@ void TabWidget::preset2Horizontal()
     TermWidgetHolder* term = reinterpret_cast<TermWidgetHolder*>(widget(ix));
     term->splitHorizontal(term->currentTerminal());
     // switch to the 1st terminal
-    term->switchNextSubterminal();
+    term->directionalNavigation(NavigationDirection::Left);
 }
 
 void TabWidget::preset2Vertical()
@@ -438,7 +446,7 @@ void TabWidget::preset2Vertical()
     TermWidgetHolder* term = reinterpret_cast<TermWidgetHolder*>(widget(ix));
     term->splitVertical(term->currentTerminal());
     // switch to the 1st terminal
-    term->switchNextSubterminal();
+    term->directionalNavigation(NavigationDirection::Left);
 }
 
 void TabWidget::preset4Terminals()
@@ -448,11 +456,11 @@ void TabWidget::preset4Terminals()
     TermWidgetHolder* term = reinterpret_cast<TermWidgetHolder*>(widget(ix));
     term->splitVertical(term->currentTerminal());
     term->splitHorizontal(term->currentTerminal());
-    term->switchNextSubterminal();
-    term->switchNextSubterminal();
+    term->directionalNavigation(NavigationDirection::Left);
+
     term->splitHorizontal(term->currentTerminal());
     // switch to the 1st terminal
-    term->switchNextSubterminal();
+    term->directionalNavigation(NavigationDirection::Top);
 }
 
 void TabWidget::showHideTabBar()

--- a/src/tabwidget.h
+++ b/src/tabwidget.h
@@ -58,8 +58,11 @@ public slots:
     void renameSession(int);
     void renameCurrentSession();
 
-    void switchNextSubterminal();
-    void switchPrevSubterminal();
+    void switchLeftSubterminal();
+    void switchRightSubterminal();
+    void switchTopSubterminal();
+    void switchBottomSubterminal();
+
     void splitHorizontally();
     void splitVertically();
     void splitCollapse();

--- a/src/termwidgetholder.h
+++ b/src/termwidgetholder.h
@@ -27,6 +27,14 @@ class QSplitter;
 
 
 
+typedef enum NavigationDirection {
+    Left,
+    Right,
+    Top,
+    Bottom
+} NavigationDirection;
+
+
 /*! \brief TermWidget group/session manager.
 
 This widget (one per TabWidget tab) is a "proxy" widget beetween TabWidget and
@@ -69,8 +77,8 @@ class TermWidgetHolder : public QWidget
         void splitHorizontal(TermWidget * term);
         void splitVertical(TermWidget * term);
         void splitCollapse(TermWidget * term);
-        void switchNextSubterminal();
-        void switchPrevSubterminal();
+        void setWDir(const QString & wdir);
+        void directionalNavigation(NavigationDirection dir);
         void clearActiveTerminal();
         void onTermTitleChanged(QString title, QString icon) const;
 
@@ -81,8 +89,11 @@ class TermWidgetHolder : public QWidget
         void termTitleChanged(QString title, QString icon) const;
 
     private:
+        QString m_wdir;
+        QString m_shell;
         TermWidget * m_currentTerm;
 
+        void split(TermWidget * term, Qt::Orientation orientation);
         TermWidget * newTerm(TerminalConfig &cfg);
 
     private slots:


### PR DESCRIPTION
This change replaces the former "next/previous" subterminal navigation with spatial left/right/top/bottom navigation based on split geometry, similar to Terminator.

This doesn't require additional bookkeeping and can be made optional, but I don't see any reason to use the older scheme over this one.

Important note: the change modifies the default control scheme to accommodate the changes, binding Ctrl+PgUp/PgDown for tab control, and using Shift+Up/Down for newly introduced "Top subterminal" and "Bottom subterminal" actions.
