### PR TITLE
Refactor dangling actions, delete windows on close

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ set(QTERM_SRC
 )
 
 set(QTERM_MOC_SRC
+    src/qterminalapp.h
     src/mainwindow.h
     src/tabwidget.h
     src/termwidget.h

--- a/src/forms/qterminal.ui
+++ b/src/forms/qterminal.ui
@@ -111,21 +111,6 @@
     <string>About &amp;Qt...</string>
    </property>
   </action>
-  <action name="actProperties">
-   <property name="text">
-    <string>&amp;Preferences...</string>
-   </property>
-  </action>
-  <action name="actQuit">
-   <property name="icon">
-    <iconset theme="application-exit">
-     <normaloff/>
-    </iconset>
-   </property>
-   <property name="text">
-    <string>&amp;Quit</string>
-   </property>
-  </action>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -22,11 +22,13 @@
 #include "ui_qterminal.h"
 
 #include <QMainWindow>
+#include <QAction>
+
 #include "qxtglobalshortcut.h"
 
 class QToolButton;
 
-class MainWindow : public QMainWindow , private Ui::mainWindow
+class MainWindow : public QMainWindow, private Ui::mainWindow
 {
     Q_OBJECT
 
@@ -36,8 +38,8 @@ public:
                QWidget * parent = 0, Qt::WindowFlags f = 0);
     ~MainWindow();
 
-    bool dropMode() const { return m_dropMode; }
-    void setup_ContextMenu_Actions(QMenu* contextMenu) const;
+    bool dropMode() { return m_dropMode; }
+    QMap<QString, QAction*> & leaseActions();
 
 protected:
      bool event(QEvent* event);
@@ -53,9 +55,14 @@ private:
 
     void setup_Action(const char *name, QAction *action, const char *defaultShortcut, const QObject *receiver,
                       const char *slot, QMenu *menu = NULL, const QVariant &data = QVariant());
+    QMap< QString, QAction * > actions;
+    
+    void rebuildActions();
+
     void setup_FileMenu_Actions();
     void setup_ActionsMenu_Actions();
     void setup_ViewMenu_Actions();
+    void setup_ContextMenu_Actions();
     void setupCustomDirs();
 
     void closeEvent(QCloseEvent*);
@@ -77,6 +84,7 @@ private slots:
     void actProperties_triggered();
     void updateActionGroup(QAction *);
 
+    void toggleBookmarks();
     void toggleBorderless();
     void toggleTabBar();
     void toggleMenu();

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -17,10 +17,12 @@
  ***************************************************************************/
 
 #include <qtermwidget.h>
+#include <assert.h>
 
 #include "properties.h"
 #include "config.h"
-
+#include "mainwindow.h"
+#include "qterminalapp.h"
 
 Properties * Properties::m_instance = 0;
 
@@ -45,7 +47,6 @@ Properties::Properties(const QString& filename)
 Properties::~Properties()
 {
     qDebug("Properties destructor called");
-    saveSettings();
     delete m_settings;
     m_instance = 0;
 }
@@ -70,16 +71,6 @@ void Properties::loadSettings()
     highlightCurrentTerminal = m_settings->value("highlightCurrentTerminal", true).toBool();
 
     font = qvariant_cast<QFont>(m_settings->value("font", defaultFont()));
-
-    m_settings->beginGroup("Shortcuts");
-    QStringList keys = m_settings->childKeys();
-    foreach( QString key, keys )
-    {
-        QKeySequence sequence = QKeySequence( m_settings->value( key ).toString() );
-        if( Properties::Instance()->actions.contains( key ) )
-            Properties::Instance()->actions[ key ]->setShortcut( sequence );
-    }
-    m_settings->endGroup();
 
     mainWindowSize = m_settings->value("MainWindow/size").toSize();
     mainWindowPosition = m_settings->value("MainWindow/pos").toPoint();
@@ -151,7 +142,10 @@ void Properties::saveSettings()
     m_settings->setValue("font", font);
 
     m_settings->beginGroup("Shortcuts");
-    QMapIterator< QString, QAction * > it(actions);
+    MainWindow *mainWindow = QTerminalApp::Instance()->getWindowList()[0];
+    assert(mainWindow != NULL);
+
+    QMapIterator< QString, QAction * > it(mainWindow->leaseActions());
     while( it.hasNext() )
     {
         it.next();

--- a/src/properties.h
+++ b/src/properties.h
@@ -22,7 +22,6 @@
 #include <QApplication>
 #include <QtCore>
 #include <QFont>
-#include <QAction>
 
 typedef QString Session;
 
@@ -94,9 +93,6 @@ class Properties
 
         bool changeWindowTitle;
         bool changeWindowIcon;
-
-        QMap< QString, QAction * > actions;
-
 
 
     private:

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -26,6 +26,7 @@
 #include "properties.h"
 #include "fontdialog.h"
 #include "config.h"
+#include "qterminalapp.h"
 
 
 PropertiesDialog::PropertiesDialog(QWidget *parent)
@@ -234,7 +235,8 @@ void PropertiesDialog::chooseBackgroundImageButton_clicked()
 
 void PropertiesDialog::saveShortcuts()
 {
-    QList< QString > shortcutKeys = Properties::Instance()->actions.keys();
+    QMap<QString, QAction*> actions = QTerminalApp::Instance()->getWindowList()[0]->leaseActions();
+    QList< QString > shortcutKeys = actions.keys();
     int shortcutCount = shortcutKeys.count();
 
     shortcutsWidget->setRowCount( shortcutCount );
@@ -242,7 +244,7 @@ void PropertiesDialog::saveShortcuts()
     for( int x=0; x < shortcutCount; x++ )
     {
         QString keyValue = shortcutKeys.at(x);
-        QAction *keyAction = Properties::Instance()->actions[keyValue];
+        QAction *keyAction = actions[keyValue];
 
         QTableWidgetItem *item = shortcutsWidget->item(x, 1);
         QKeySequence sequence = QKeySequence(item->text());
@@ -253,11 +255,13 @@ void PropertiesDialog::saveShortcuts()
             shortcuts.append(QKeySequence(sequenceString));
         keyAction->setShortcuts(shortcuts);
     }
+    Properties::Instance()->saveSettings();
 }
 
 void PropertiesDialog::setupShortcuts()
 {
-    QList< QString > shortcutKeys = Properties::Instance()->actions.keys();
+    QMap<QString, QAction*> actions = QTerminalApp::Instance()->getWindowList()[0]->leaseActions();
+    QList< QString > shortcutKeys = actions.keys();
     int shortcutCount = shortcutKeys.count();
 
     shortcutsWidget->setRowCount( shortcutCount );
@@ -265,7 +269,7 @@ void PropertiesDialog::setupShortcuts()
     for( int x=0; x < shortcutCount; x++ )
     {
         QString keyValue = shortcutKeys.at(x);
-        QAction *keyAction = Properties::Instance()->actions[keyValue];
+        QAction *keyAction = actions[keyValue];
         QStringList sequenceStrings;
 
         foreach (QKeySequence shortcut, keyAction->shortcuts())

--- a/src/qterminalapp.h
+++ b/src/qterminalapp.h
@@ -1,0 +1,44 @@
+#ifndef QTERMINALAPP_H
+#define QTERMINALAPP_H
+
+#include <QApplication>
+
+#include "mainwindow.h"
+
+
+class QTerminalApp : public QApplication
+{
+Q_OBJECT
+
+public:
+    MainWindow *newWindow(bool dropMode, const QString& workdir, const QString& shell_command);
+    QList<MainWindow*> getWindowList();
+    void addWindow(MainWindow *window);
+    void removeWindow(MainWindow *window);
+	static QTerminalApp *Instance(int &argc, char **argv);
+	static QTerminalApp *Instance();
+
+private:
+	QList<MainWindow *> m_windowList;
+	static QTerminalApp *m_instance;
+	QTerminalApp(int &argc, char **argv);
+	~QTerminalApp(){};
+};
+
+template <class T> T* findParent(QObject *child)
+{
+    QObject *maybeT = child;
+    while (true)
+    {
+        if (maybeT == NULL)
+        {
+            return NULL;
+        }
+        T *holder = qobject_cast<T*>(maybeT);
+        if (holder)
+            return holder;
+        maybeT = maybeT->parent();
+    }
+}
+
+#endif

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -21,10 +21,12 @@
 #include <QMouseEvent>
 #include <QMenu>
 
+#include "mainwindow.h"
 #include "termwidgetholder.h"
 #include "tabwidget.h"
 #include "config.h"
 #include "properties.h"
+#include "qterminalapp.h"
 
 
 #define TAB_INDEX_PROPERTY "tab_index"
@@ -206,10 +208,11 @@ void TabWidget::renameTabsAfterRemove()
 void TabWidget::contextMenuEvent(QContextMenuEvent *event)
 {
     QMenu menu(this);
+    QMap< QString, QAction * > actions = findParent<MainWindow>(this)->leaseActions();
 
     QAction *close = menu.addAction(QIcon::fromTheme("document-close"), tr("Close session"));
-    QAction *rename = menu.addAction(Properties::Instance()->actions[RENAME_SESSION]->text());
-    rename->setShortcut(Properties::Instance()->actions[RENAME_SESSION]->shortcut());
+    QAction *rename = menu.addAction(actions[RENAME_SESSION]->text());
+    rename->setShortcut(actions[RENAME_SESSION]->shortcut());
     rename->blockSignals(true);
 
     int tabIndex = tabBar()->tabAt(event->pos());

--- a/src/tabwidget.h
+++ b/src/tabwidget.h
@@ -21,6 +21,8 @@
 
 #include <QTabWidget>
 #include <QMap>
+#include <QAction>
+
 
 #include "properties.h"
 

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -20,11 +20,13 @@
 #include <QVBoxLayout>
 #include <QPainter>
 #include <QDesktopServices>
+#include <assert.h>
 
+#include "mainwindow.h"
 #include "termwidget.h"
 #include "config.h"
 #include "properties.h"
-#include "mainwindow.h"
+#include "qterminalapp.h"
 
 static int TermWidgetCount = 0;
 
@@ -125,20 +127,25 @@ void TermWidgetImpl::propertiesChanged()
 
 void TermWidgetImpl::customContextMenuCall(const QPoint & pos)
 {
-    QMenu* contextMenu = new QMenu(this);
+    QMenu menu;
+    QMap<QString, QAction*> actions = findParent<MainWindow>(this)->leaseActions();
 
-    QList<QAction*> actions = filterActions(pos);
-    for (auto& action : actions)
-    {
-        contextMenu->addAction(action);
-    }
-
-    contextMenu->addSeparator();
-
-    const MainWindow *main = qobject_cast<MainWindow*>(window());
-    main->setup_ContextMenu_Actions(contextMenu);
-
-    contextMenu->exec(mapToGlobal(pos));
+    menu.addAction(actions[COPY_SELECTION]);
+    menu.addAction(actions[PASTE_CLIPBOARD]);
+    menu.addAction(actions[PASTE_SELECTION]);
+    menu.addAction(actions[ZOOM_IN]);
+    menu.addAction(actions[ZOOM_OUT]);
+    menu.addAction(actions[ZOOM_RESET]);
+    menu.addSeparator();
+    menu.addAction(actions[CLEAR_TERMINAL]);
+    menu.addAction(actions[SPLIT_HORIZONTAL]);
+    menu.addAction(actions[SPLIT_VERTICAL]);
+#warning TODO/FIXME: disable the action when there is only one terminal
+    menu.addAction(actions[SUB_COLLAPSE]);
+    menu.addSeparator();
+    menu.addAction(actions[TOGGLE_MENU]);
+    menu.addAction(actions[PREFERENCES]);
+    menu.exec(mapToGlobal(pos));
 }
 
 void TermWidgetImpl::zoomIn()


### PR DESCRIPTION
These changes (probably partially) fix https://github.com/lxde/qterminal/issues/156
As a side effect, it changes the behavior where newly set shortcuts from Properties didn't apply to all windows.

Current version of QTerminal never deletes windows that are open via File->New Window, leading to out-of-control memory growth on prolonged use.
This patch allows use of setAttribute(Qt::WA_DeleteOnClose), or manual window deletion without harmful side effects.

This requires major refactoring of actions, since the previous implementation creates a lot of dangling pointers attached to Properties->actions on parent MainWindow deletion.

Since the changeset is unfortunately rather large, here's a breakdown of changes:
- Each MainWindow now has its own set of QActions, since those are destroyed along with their parent.
- There's a registry for MainWindows in singleton QTerminalApp, subclassed from QApplication
- Reusable actions are now only added dynamically, not via MOC, to allow for unified deletion and re-creation on setting changes.
- MainWindow children now use corresponding actions from parent MainWindow, allowing for their and actions' safe removal.
- To avoid code duplication, Properties and PropertiesDialog now use actions from the first MainWindow they find.
