### PR TITLE
Focus highlight

### DIFF
--- a/src/forms/qterminal.ui
+++ b/src/forms/qterminal.ui
@@ -32,12 +32,6 @@
     </property>
     <item row="0" column="0">
      <widget class="TabWidget" name="consoleTabulator">
-      <property name="minimumSize">
-       <size>
-        <width>320</width>
-        <height>200</height>
-       </size>
-      </property>
       <property name="tabPosition">
        <enum>QTabWidget::South</enum>
       </property>

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -217,10 +217,13 @@ void TermWidget::term_termLostFocus()
 
 void TermWidget::paintEvent (QPaintEvent *)
 {
-    QPainter p(this);
-    QPen pen(m_border);
-    pen.setWidth(30);
-    pen.setBrush(m_border);
-    p.setPen(pen);
-    p.drawRect(0, 0, width()-1, height()-1);
+  if (Properties::Instance()->highlightCurrentTerminal)
+    {
+      QPainter p(this);
+      QPen pen(m_border);
+      pen.setWidth(3);
+      pen.setBrush(m_border);
+      p.setPen(pen);
+      p.drawRect(0, 0, width()-1, height()-1);
+    }
 }


### PR DESCRIPTION
Fix for extra large border on SearchBar widget as seen in Issue #249 
