### PR TITLE
Change "Clear Current Tab" --> "Clear Active Terminal"

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -204,7 +204,7 @@ void MainWindow::setup_ActionsMenu_Actions()
 
     menu_Actions->clear();
 
-    setup_Action(CLEAR_TERMINAL, new QAction(QIcon::fromTheme("edit-clear"), tr("&Clear Current Tab"), settingOwner),
+    setup_Action(CLEAR_TERMINAL, new QAction(QIcon::fromTheme("edit-clear"), tr("&Clear Active Terminal"), settingOwner),
                  CLEAR_TERMINAL_SHORTCUT, consoleTabulator, SLOT(clearActiveTerminal()), menu_Actions);
 
     menu_Actions->addSeparator();


### PR DESCRIPTION
fixes #267 - we must change the translations too, but i'm not familar with the Qt translation system
