### PR TITLE
Use the new lxqt-build-tools package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(qterminal)
 include(GNUInstallDirs)
 
 set(STR_VERSION "0.7.0")
+set(LXQTBT_MINIMUM_VERSION "0.1.0")
 
 
 # additional cmake files
@@ -35,8 +36,7 @@ elseif(UNIX)
     find_package(Qt5X11Extras REQUIRED)
 endif()
 find_package(QTermWidget5 REQUIRED)
-#Note: no run-time dependency on liblxqt, just a build dependency for lxqt_translate_ts/desktop
-find_package(lxqt REQUIRED)
+find_package(lxqt-build-tools ${LXQTBT_MINIMUM_VERSION} REQUIRED)
 include(LXQtTranslateTs)
 message(STATUS "Qt version: ${Qt5Core_VERSION_STRING}")
 


### PR DESCRIPTION
Drop liblxqt build time dependency.