### PR TITLE
Set the maximum value for dropdown width and height spinboxes to 100

### DIFF
--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -114,8 +114,12 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
     historyLimitedTo->setValue(Properties::Instance()->historyLimitedTo);
 
     dropShowOnStartCheckBox->setChecked(Properties::Instance()->dropShowOnStart);
+
     dropHeightSpinBox->setValue(Properties::Instance()->dropHeight);
+    dropHeightSpinBox->setMaximum(100);
     dropWidthSpinBox->setValue(Properties::Instance()->dropWidht);
+    dropWidthSpinBox->setMaximum(100);
+
     dropShortCutEdit->setText(Properties::Instance()->dropShortCut.toString());
 
     useBookmarksCheckBox->setChecked(Properties::Instance()->useBookmarks);


### PR DESCRIPTION
The default appears to be 99, and I prefer that the dropdown be full-width (100). This allows users to set a dropdown width up to 100%, instead of 99%.