### PR TITLE
Add context menu actions for URLs and E-Mail addresses

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -91,7 +91,6 @@ MainWindow::MainWindow(const QString& work_dir,
     setup_FileMenu_Actions();
     setup_ActionsMenu_Actions();
     setup_ViewMenu_Actions();
-    setup_ContextMenu_Actions();
     setupCustomDirs();
 
     connect(consoleTabulator, &TabWidget::currentTitleChanged, this, &MainWindow::onCurrentTitleChanged);
@@ -507,24 +506,23 @@ void MainWindow::setup_ViewMenu_Actions()
     menu_Window->addMenu(keyboardCursorShapeMenu);
 }
 
-void MainWindow::setup_ContextMenu_Actions()
+void MainWindow::setup_ContextMenu_Actions(QMenu* contextMenu) const
 {
-    m_contextMenu = new QMenu(this);
-    m_contextMenu->addAction(Properties::Instance()->actions[COPY_SELECTION]);
-    m_contextMenu->addAction(Properties::Instance()->actions[PASTE_CLIPBOARD]);
-    m_contextMenu->addAction(Properties::Instance()->actions[PASTE_SELECTION]);
-    m_contextMenu->addAction(Properties::Instance()->actions[ZOOM_IN]);
-    m_contextMenu->addAction(Properties::Instance()->actions[ZOOM_OUT]);
-    m_contextMenu->addAction(Properties::Instance()->actions[ZOOM_RESET]);
-    m_contextMenu->addSeparator();
-    m_contextMenu->addAction(Properties::Instance()->actions[CLEAR_TERMINAL]);
-    m_contextMenu->addAction(Properties::Instance()->actions[SPLIT_HORIZONTAL]);
-    m_contextMenu->addAction(Properties::Instance()->actions[SPLIT_VERTICAL]);
+    contextMenu->addAction(Properties::Instance()->actions[COPY_SELECTION]);
+    contextMenu->addAction(Properties::Instance()->actions[PASTE_CLIPBOARD]);
+    contextMenu->addAction(Properties::Instance()->actions[PASTE_SELECTION]);
+    contextMenu->addAction(Properties::Instance()->actions[ZOOM_IN]);
+    contextMenu->addAction(Properties::Instance()->actions[ZOOM_OUT]);
+    contextMenu->addAction(Properties::Instance()->actions[ZOOM_RESET]);
+    contextMenu->addSeparator();
+    contextMenu->addAction(Properties::Instance()->actions[CLEAR_TERMINAL]);
+    contextMenu->addAction(Properties::Instance()->actions[SPLIT_HORIZONTAL]);
+    contextMenu->addAction(Properties::Instance()->actions[SPLIT_VERTICAL]);
     #warning TODO/FIXME: disable the action when there is only one terminal
-    m_contextMenu->addAction(Properties::Instance()->actions[SUB_COLLAPSE]);
-    m_contextMenu->addSeparator();
-    m_contextMenu->addAction(Properties::Instance()->actions[TOGGLE_MENU]);
-    m_contextMenu->addAction(Properties::Instance()->actions[PREFERENCES]);
+    contextMenu->addAction(Properties::Instance()->actions[SUB_COLLAPSE]);
+    contextMenu->addSeparator();
+    contextMenu->addAction(Properties::Instance()->actions[TOGGLE_MENU]);
+    contextMenu->addAction(Properties::Instance()->actions[PREFERENCES]);
 }
 
 void MainWindow::setupCustomDirs()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -37,7 +37,7 @@ public:
     ~MainWindow();
 
     bool dropMode() const { return m_dropMode; }
-    QMenu *getContextMenu() const { return m_contextMenu; }
+    void setup_ContextMenu_Actions(QMenu* contextMenu) const;
 
 protected:
      bool event(QEvent* event);
@@ -50,12 +50,10 @@ private:
     QString m_initShell;
 
     QDockWidget *m_bookmarksDock;
-    QMenu * m_contextMenu;
 
     void setup_FileMenu_Actions();
     void setup_ActionsMenu_Actions();
     void setup_ViewMenu_Actions();
-    void setup_ContextMenu_Actions();
     void setupCustomDirs();
 
     void closeEvent(QCloseEvent*);

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -68,7 +68,7 @@ TermWidgetImpl::TermWidgetImpl(const QString & wdir, const QString & shell, QWid
     connect(this, SIGNAL(customContextMenuRequested(const QPoint &)),
             this, SLOT(customContextMenuCall(const QPoint &)));
 
-    connect(this, SIGNAL(urlActivated(QUrl)), this, SLOT(activateUrl(const QUrl&)));
+    connect(this, &QTermWidget::urlActivated, this, &TermWidgetImpl::activateUrl);
 
     startShellProgram();
 }
@@ -124,8 +124,20 @@ void TermWidgetImpl::propertiesChanged()
 
 void TermWidgetImpl::customContextMenuCall(const QPoint & pos)
 {
+    QMenu* contextMenu = new QMenu(this);
+
+    QList<QAction*> actions = filterActions(pos);
+    for (auto& action : actions)
+    {
+        contextMenu->addAction(action);
+    }
+
+    contextMenu->addSeparator();
+
     const MainWindow *main = qobject_cast<MainWindow*>(window());
-    main->getContextMenu()->exec(mapToGlobal(pos));
+    main->setup_ContextMenu_Actions(contextMenu);
+
+    contextMenu->exec(mapToGlobal(pos));
 }
 
 void TermWidgetImpl::zoomIn()
@@ -152,8 +164,8 @@ void TermWidgetImpl::zoomReset()
 //    Properties::Instance()->saveSettings();
 }
 
-void TermWidgetImpl::activateUrl(const QUrl & url) {
-    if (QApplication::keyboardModifiers() & Qt::ControlModifier) {
+void TermWidgetImpl::activateUrl(const QUrl & url, bool fromContextMenu) {
+    if (QApplication::keyboardModifiers() & Qt::ControlModifier || fromContextMenu) {
         QDesktopServices::openUrl(url);
     }
 }

--- a/src/termwidget.h
+++ b/src/termwidget.h
@@ -46,7 +46,7 @@ class TermWidgetImpl : public QTermWidget
 
     private slots:
         void customContextMenuCall(const QPoint & pos);
-        void activateUrl(const QUrl& url);
+        void activateUrl(const QUrl& url, bool fromContextMenu);
 };
 
 


### PR DESCRIPTION
Implements #152

Depens on https://github.com/lxde/qtermwidget/pull/97

Context menus are now generated dynamically. According to valgrind, there are no memory leaks in the line `QMenu* contextMenu = new QMenu(this);`. I guess Qt is handling things well.
