### PR TITLE
Fix tabstop order in properties dialog & add buddy relations for labels.

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -82,7 +82,7 @@
      <property name="currentIndex">
       <number>0</number>
      </property>
-     <widget class="QWidget" name="lookAndFeelPage">
+     <widget class="QWidget" name="appearancePage">
       <layout class="QGridLayout" name="gridLayout_3">
        <item row="8" column="0">
         <widget class="QCheckBox" name="hideTabBarCheckBox">
@@ -99,6 +99,9 @@
          <property name="text">
           <string>Color scheme</string>
          </property>
+         <property name="buddy">
+          <cstring>colorSchemaCombo</cstring>
+         </property>
         </widget>
        </item>
        <item row="4" column="0">
@@ -106,12 +109,18 @@
          <property name="text">
           <string>Scrollbar position</string>
          </property>
+         <property name="buddy">
+          <cstring>scrollBarPos_comboBox</cstring>
+         </property>
         </widget>
        </item>
        <item row="14" column="0">
         <widget class="QLabel" name="label_9">
          <property name="text">
           <string>Start with preset:</string>
+         </property>
+         <property name="buddy">
+          <cstring>terminalPresetComboBox</cstring>
          </property>
         </widget>
        </item>
@@ -131,14 +140,17 @@
        <item row="13" column="0">
         <widget class="QLabel" name="label">
          <property name="text">
-          <string>Terminal transparency</string>
+          <string>Ter&amp;minal transparency</string>
+         </property>
+         <property name="buddy">
+          <cstring>termTransparencyBox</cstring>
          </property>
         </widget>
        </item>
        <item row="12" column="0">
         <widget class="QLabel" name="label_4">
          <property name="text">
-          <string>Application transparency</string>
+          <string>App&amp;lication transparency</string>
          </property>
          <property name="buddy">
           <cstring>appTransparencyBox</cstring>
@@ -205,6 +217,9 @@
             <property name="text">
              <string>Font</string>
             </property>
+            <property name="buddy">
+             <cstring>changeFontButton</cstring>
+            </property>
            </widget>
           </item>
           <item>
@@ -248,6 +263,9 @@
          <property name="text">
           <string>Tabs position</string>
          </property>
+         <property name="buddy">
+          <cstring>tabsPos_comboBox</cstring>
+         </property>
         </widget>
        </item>
        <item row="3" column="1">
@@ -277,6 +295,9 @@
          <property name="text">
           <string>Widget style</string>
          </property>
+         <property name="buddy">
+          <cstring>styleComboBox</cstring>
+         </property>
         </widget>
        </item>
        <item row="15" column="0" colspan="2">
@@ -304,6 +325,9 @@
          <property name="text">
           <string>Keyboard cursor shape</string>
          </property>
+         <property name="buddy">
+          <cstring>keybCursorShape_comboBox</cstring>
+         </property>
         </widget>
        </item>
        <item row="10" column="0" colspan="2">
@@ -322,7 +346,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="historyPage">
+     <widget class="QWidget" name="behaviorPage">
       <layout class="QGridLayout" name="gridLayout_5">
        <item row="2" column="0">
         <spacer name="verticalSpacer_2">
@@ -372,6 +396,9 @@
            <widget class="QLabel" name="label_3">
             <property name="text">
              <string>Action after paste</string>
+            </property>
+            <property name="buddy">
+             <cstring>motionAfterPasting_comboBox</cstring>
             </property>
            </widget>
           </item>
@@ -435,14 +462,14 @@
           <item row="1" column="0" colspan="3">
            <widget class="QRadioButton" name="historyUnlimited">
             <property name="text">
-             <string>Unlimited history</string>
+             <string>Unli&amp;mited history</string>
             </property>
            </widget>
           </item>
           <item row="0" column="0">
            <widget class="QRadioButton" name="historyLimited">
             <property name="text">
-             <string>History size (in lines)</string>
+             <string>History size (in &amp;lines)</string>
             </property>
            </widget>
           </item>
@@ -487,7 +514,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="page">
+     <widget class="QWidget" name="dropdownPage">
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
         <widget class="QCheckBox" name="dropShowOnStartCheckBox">
@@ -512,6 +539,9 @@
               <property name="text">
                <string>Height</string>
               </property>
+              <property name="buddy">
+               <cstring>dropHeightSpinBox</cstring>
+              </property>
              </widget>
             </item>
             <item row="0" column="1">
@@ -525,6 +555,9 @@
              <widget class="QLabel" name="dropWidthLabel">
               <property name="text">
                <string>Width</string>
+              </property>
+              <property name="buddy">
+               <cstring>dropWidthSpinBox</cstring>
               </property>
              </widget>
             </item>
@@ -546,6 +579,9 @@
           <widget class="QLabel" name="dropShortCutLabel">
            <property name="text">
             <string>Shortcut:</string>
+           </property>
+           <property name="buddy">
+            <cstring>dropShortCutEdit</cstring>
            </property>
           </widget>
          </item>
@@ -569,7 +605,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="page_2">
+     <widget class="QWidget" name="bookmarksPage">
       <layout class="QGridLayout" name="gridLayout_9">
        <item row="3" column="0">
         <widget class="QGroupBox" name="groupBox_5">
@@ -605,7 +641,10 @@
          <item>
           <widget class="QLabel" name="label_10">
            <property name="text">
-            <string>Bookmark file</string>
+            <string>Book&amp;mark file</string>
+           </property>
+           <property name="buddy">
+            <cstring>bookmarksLineEdit</cstring>
            </property>
           </widget>
          </item>
@@ -637,6 +676,41 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>listWidget</tabstop>
+  <tabstop>changeFontButton</tabstop>
+  <tabstop>colorSchemaCombo</tabstop>
+  <tabstop>styleComboBox</tabstop>
+  <tabstop>scrollBarPos_comboBox</tabstop>
+  <tabstop>tabsPos_comboBox</tabstop>
+  <tabstop>keybCursorShape_comboBox</tabstop>
+  <tabstop>showMenuCheckBox</tabstop>
+  <tabstop>hideTabBarCheckBox</tabstop>
+  <tabstop>highlightCurrentCheckBox</tabstop>
+  <tabstop>changeWindowTitleCheckBox</tabstop>
+  <tabstop>changeWindowIconCheckBox</tabstop>
+  <tabstop>appTransparencyBox</tabstop>
+  <tabstop>termTransparencyBox</tabstop>
+  <tabstop>terminalPresetComboBox</tabstop>
+  <tabstop>historyLimited</tabstop>
+  <tabstop>historyUnlimited</tabstop>
+  <tabstop>historyLimitedTo</tabstop>
+  <tabstop>motionAfterPasting_comboBox</tabstop>
+  <tabstop>askOnExitCheckBox</tabstop>
+  <tabstop>savePosOnExitCheckBox</tabstop>
+  <tabstop>saveSizeOnExitCheckBox</tabstop>
+  <tabstop>useCwdCheckBox</tabstop>
+  <tabstop>emulationComboBox</tabstop>
+  <tabstop>shortcutsWidget</tabstop>
+  <tabstop>dropShowOnStartCheckBox</tabstop>
+  <tabstop>dropHeightSpinBox</tabstop>
+  <tabstop>dropWidthSpinBox</tabstop>
+  <tabstop>dropShortCutEdit</tabstop>
+  <tabstop>useBookmarksCheckBox</tabstop>
+  <tabstop>bookmarksLineEdit</tabstop>
+  <tabstop>bookmarksButton</tabstop>
+  <tabstop>bookmarkPlainEdit</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
Trying to tab through the widgets of the properties dialog is frustrating.

I fixed the tabstop order - while I was at it I renamed the pages and added buddy relations to labels where it seemed appropriate.