### PR TITLE
Properly clean up QApp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -145,6 +145,7 @@ int main(int argc, char *argv[])
 
     int ret = app->exec();
     delete Properties::Instance();
+    app->cleanup();
 
     return ret;
 }
@@ -183,6 +184,11 @@ QTerminalApp *QTerminalApp::Instance(int &argc, char **argv)
 QTerminalApp::QTerminalApp(int &argc, char **argv)
     :QApplication(argc, argv)
 {
+}
+
+void QTerminalApp::cleanup() {
+    delete m_instance;
+    m_instance = NULL;
 }
 
 

--- a/src/qterminalapp.h
+++ b/src/qterminalapp.h
@@ -17,6 +17,7 @@ public:
     void removeWindow(MainWindow *window);
 	static QTerminalApp *Instance(int &argc, char **argv);
 	static QTerminalApp *Instance();
+    static void cleanup();
 
 private:
 	QList<MainWindow *> m_windowList;


### PR DESCRIPTION
Following the comments from @palinek, added a proper call to the destructor for `QApplication` singleton. Not doing so might lead to the cryptic SEGFAULTS at the exit.