### PR TITLE
DBus integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ set(QTERM_SRC
     src/tabwidget.cpp
     src/termwidget.cpp
     src/termwidgetholder.cpp
+    src/terminalconfig.cpp
     src/properties.cpp
     src/propertiesdialog.cpp
     src/bookmarkswidget.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(Qt5LinguistTools REQUIRED)
 if(APPLE)
 elseif(UNIX)
     find_package(Qt5X11Extras REQUIRED)
+    find_package(Qt5DBus)
 endif()
 find_package(QTermWidget5 REQUIRED)
 find_package(lxqt-build-tools ${LXQTBT_MINIMUM_VERSION} REQUIRED)
@@ -55,6 +56,7 @@ set(QTERM_SRC
     src/propertiesdialog.cpp
     src/bookmarkswidget.cpp
     src/fontdialog.cpp
+    src/dbusaddressable.cpp
 )
 
 set(QTERM_MOC_SRC
@@ -67,6 +69,17 @@ set(QTERM_MOC_SRC
     src/bookmarkswidget.h
     src/fontdialog.h
 )
+
+
+if (Qt5DBus_FOUND)
+    add_definitions(-DHAVE_QDBUS)
+    QT5_ADD_DBUS_ADAPTOR(QTERM_SRC src/org.lxqt.QTerminal.Window.xml mainwindow.h MainWindow)
+    QT5_ADD_DBUS_ADAPTOR(QTERM_SRC src/org.lxqt.QTerminal.Tab.xml termwidgetholder.h TermWidgetHolder)
+    QT5_ADD_DBUS_ADAPTOR(QTERM_SRC src/org.lxqt.QTerminal.Terminal.xml termwidget.h TermWidget)
+    QT5_ADD_DBUS_ADAPTOR(QTERM_SRC src/org.lxqt.QTerminal.Process.xml qterminalapp.h QTerminalApp)
+    set(QTERM_MOC_SRC ${QTERM_MOC_SRC} src/dbusaddressable.h)
+    message(STATUS "Building with Qt5DBus support")
+endif()
 
 if(NOT QXT_FOUND)
     set(QTERM_SRC ${QTERM_SRC} src/third-party/qxtglobalshortcut.cpp)
@@ -166,6 +179,10 @@ target_link_libraries(${EXE_NAME}
 )
 if(QXT_FOUND)
     target_link_libraries(${EXE_NAME} ${QXT_CORE_LIB} ${QXT_GUI_LIB})
+endif()
+
+if (Qt5DBus_FOUND)
+    target_link_libraries(${EXE_NAME} ${Qt5DBus_LIBRARIES})
 endif()
 
 if(APPLE)

--- a/src/dbusaddressable.cpp
+++ b/src/dbusaddressable.cpp
@@ -1,0 +1,25 @@
+
+
+#include "dbusaddressable.h"
+
+#ifdef HAVE_QDBUS
+Q_DECLARE_METATYPE(QList<QDBusObjectPath>)
+
+QString DBusAddressable::getDbusPathString()
+{
+    return m_path;
+}
+
+QDBusObjectPath DBusAddressable::getDbusPath()
+{
+    return QDBusObjectPath(m_path);
+}
+#endif
+
+DBusAddressable::DBusAddressable(QString prefix)
+{
+    #ifdef HAVE_QDBUS
+    QString uuidString = QUuid::createUuid().toString();
+    m_path = prefix + "/" + uuidString.replace(QRegExp("[\\{\\}\\-]"), "");
+    #endif
+}

--- a/src/dbusaddressable.h
+++ b/src/dbusaddressable.h
@@ -1,0 +1,34 @@
+#ifndef DBUSADDRESSABLE_H
+#define DBUSADDRESSABLE_H
+
+#include <QString>
+#ifdef HAVE_QDBUS
+#include <QtDBus/QtDBus>
+#include <QUuid>
+#endif
+
+class DBusAddressable
+{
+    #ifdef HAVE_QDBUS
+    private:
+        QString m_path;
+    #endif
+    public:
+    #ifdef HAVE_QDBUS
+        QDBusObjectPath getDbusPath();
+        QString getDbusPathString();
+    #endif
+        DBusAddressable(QString prefix);
+};
+
+#ifdef HAVE_QDBUS
+template <class AClass, class WClass> void registerAdapter(WClass *obj)
+{
+    new AClass(obj);
+    QString path = dynamic_cast<DBusAddressable*>(obj)->getDbusPathString();
+    QDBusConnection::sessionBus().registerObject(path, obj);
+}
+#endif
+
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,7 @@
 
 #include "mainwindow.h"
 #include "qterminalapp.h"
+#include "terminalconfig.h"
 
 #define out
 
@@ -122,6 +123,7 @@ int main(int argc, char *argv[])
 
     if (workdir.isEmpty())
         workdir = QDir::currentPath();
+    app->setWorkingDirectory(workdir);
 
     // icons
     /* setup our custom icon theme if there is no system theme (OS X, Windows) */
@@ -141,7 +143,8 @@ int main(int argc, char *argv[])
 #endif
     app->installTranslator(&translator);
 
-    app->newWindow(dropMode, workdir, shell_command);
+    TerminalConfig initConfig = TerminalConfig(workdir, shell_command);
+    app->newWindow(dropMode, initConfig);
 
     int ret = app->exec();
     delete Properties::Instance();
@@ -149,19 +152,19 @@ int main(int argc, char *argv[])
     return ret;
 }
 
-MainWindow *QTerminalApp::newWindow(bool dropMode, const QString& workdir, const QString& shell_command)
+MainWindow *QTerminalApp::newWindow(bool dropMode, TerminalConfig &cfg)
 {
     MainWindow *window = NULL;
     if (dropMode)
     {
         QWidget *hiddenPreviewParent = new QWidget(0, Qt::Tool);
-        window = new MainWindow(workdir, shell_command, dropMode, hiddenPreviewParent);
+        window = new MainWindow(cfg, dropMode, hiddenPreviewParent);
         if (Properties::Instance()->dropShowOnStart)
             window->show();
     }
     else
     {
-        window = new MainWindow(workdir, shell_command, dropMode);
+        window = new MainWindow(cfg, dropMode);
         window->show();
     }
     return window;
@@ -183,6 +186,16 @@ QTerminalApp *QTerminalApp::Instance(int &argc, char **argv)
 QTerminalApp::QTerminalApp(int &argc, char **argv)
     :QApplication(argc, argv)
 {
+}
+
+QString &QTerminalApp::getWorkingDirectory()
+{
+    return m_workDir;
+}
+
+void QTerminalApp::setWorkingDirectory(const QString &wd)
+{
+    m_workDir = wd;
 }
 
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -26,11 +26,12 @@
 
 #include "qxtglobalshortcut.h"
 #include "terminalconfig.h"
+#include "dbusaddressable.h"
 
 
 class QToolButton;
 
-class MainWindow : public QMainWindow, private Ui::mainWindow
+class MainWindow : public QMainWindow, private Ui::mainWindow, public DBusAddressable
 {
     Q_OBJECT
 
@@ -42,6 +43,13 @@ public:
 
     bool dropMode() { return m_dropMode; }
     QMap<QString, QAction*> & leaseActions();
+
+    #ifdef HAVE_QDBUS
+    QDBusObjectPath getActiveTab();
+    QList<QDBusObjectPath> getTabs();
+    QDBusObjectPath newTab(const QHash<QString,QVariant> &termArgs);
+    void closeWindow();
+    #endif
 
 protected:
      bool event(QEvent* event);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -25,6 +25,8 @@
 #include <QAction>
 
 #include "qxtglobalshortcut.h"
+#include "terminalconfig.h"
+
 
 class QToolButton;
 
@@ -33,7 +35,7 @@ class MainWindow : public QMainWindow, private Ui::mainWindow
     Q_OBJECT
 
 public:
-    MainWindow(const QString& work_dir, const QString& command,
+    MainWindow(TerminalConfig& cfg,
                bool dropMode,
                QWidget * parent = 0, Qt::WindowFlags f = 0);
     ~MainWindow();
@@ -48,8 +50,7 @@ private:
     QActionGroup *tabPosition, *scrollBarPosition, *keyboardCursorShape;
     QMenu *tabPosMenu, *scrollPosMenu, *keyboardCursorShapeMenu;
 
-    QString m_initWorkDir;
-    QString m_initShell;
+    TerminalConfig m_config;
 
     QDockWidget *m_bookmarksDock;
 

--- a/src/org.lxqt.QTerminal.Process.xml
+++ b/src/org.lxqt.QTerminal.Process.xml
@@ -1,0 +1,17 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="org.lxqt.QTerminal.Process">
+    <method name="getWindows">
+      <arg name="windows" type="ao" direction="out"/>
+    </method>
+    <method name="newWindow">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QHash&lt;QString,QVariant&gt;"/>
+      <arg name="termArgs" type="a{sv}" direction="in"/>
+    </method>
+    <method name="getActiveWindow">
+      <arg name="window" type="o" direction="out"/>
+    </method>
+  </interface>
+</node>
+

--- a/src/org.lxqt.QTerminal.Tab.xml
+++ b/src/org.lxqt.QTerminal.Tab.xml
@@ -1,0 +1,17 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="org.lxqt.QTerminal.Tab">
+    <method name="getActiveTerminal">
+      <arg name="terminal" type="o" direction="out"/>
+    </method>
+    <method name="getTerminals">
+      <arg name="terminals" type="ao" direction="out"/>
+    </method>
+    <method name="getWindow">
+      <arg name="window" type="o" direction="out"/>
+    </method>
+    <method name="closeTab"/>
+  </interface>
+</node>
+

--- a/src/org.lxqt.QTerminal.Terminal.xml
+++ b/src/org.lxqt.QTerminal.Terminal.xml
@@ -1,0 +1,24 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="org.lxqt.QTerminal.Terminal">
+    <method name="splitVertical">
+        <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QHash&lt;QString,QVariant&gt;"/>
+        <arg name="termArgs" type="a{sv}" direction="in"/>
+        <arg name="newTerminal" type="o" direction="out"/>
+    </method>
+    <method name="splitHorizontal">
+        <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QHash&lt;QString,QVariant&gt;"/>
+        <arg name="termArgs" type="a{sv}" direction="in"/>
+        <arg name="newTerminal" type="o" direction="out"/>
+    </method>
+    <method name="getTab">
+        <arg name="tab" type="o" direction="out"/>
+    </method>
+    <method name="sendText">
+        <arg name="text" type="s" direction="in"/>
+    </method>
+    <method name="closeTerminal"/>
+  </interface>
+</node>
+

--- a/src/org.lxqt.QTerminal.Window.xml
+++ b/src/org.lxqt.QTerminal.Window.xml
@@ -14,6 +14,7 @@
       <arg name="newTerminal" type="o" direction="out"/>
     </method>
     <method name="closeWindow"/>
+    <method name="activateWindow"/>
   </interface>
 </node>
 

--- a/src/org.lxqt.QTerminal.Window.xml
+++ b/src/org.lxqt.QTerminal.Window.xml
@@ -1,0 +1,19 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+  <interface name="org.lxqt.QTerminal.Window">
+    <method name="getTabs">
+      <arg name="tabs" type="ao" direction="out"/>
+    </method>
+    <method name="getActiveTab">
+      <arg name="tab" type="o" direction="out"/>
+    </method>
+    <method name="newTab">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QHash&lt;QString,QVariant&gt;"/>
+      <arg name="termArgs" type="a{sv}" direction="in"/>
+      <arg name="newTerminal" type="o" direction="out"/>
+    </method>
+    <method name="closeWindow"/>
+  </interface>
+</node>
+

--- a/src/qterminalapp.h
+++ b/src/qterminalapp.h
@@ -2,6 +2,9 @@
 #define QTERMINALAPP_H
 
 #include <QApplication>
+#ifdef HAVE_QDBUS
+    #include <QtDBus/QtDBus>
+#endif
 
 
 #include "mainwindow.h"
@@ -21,6 +24,12 @@ public:
     QString &getWorkingDirectory();
     void setWorkingDirectory(const QString &wd);
 
+    #ifdef HAVE_QDBUS
+    void registerOnDbus();
+    QList<QDBusObjectPath> getWindows();
+    QDBusObjectPath newWindow(const QHash<QString,QVariant> &termArgs);
+    QDBusObjectPath getActiveWindow();
+    #endif
 
 private:
     QString m_workDir;

--- a/src/qterminalapp.h
+++ b/src/qterminalapp.h
@@ -3,6 +3,7 @@
 
 #include <QApplication>
 
+
 #include "mainwindow.h"
 
 
@@ -11,18 +12,22 @@ class QTerminalApp : public QApplication
 Q_OBJECT
 
 public:
-    MainWindow *newWindow(bool dropMode, const QString& workdir, const QString& shell_command);
+    MainWindow *newWindow(bool dropMode, TerminalConfig &cfg);
     QList<MainWindow*> getWindowList();
     void addWindow(MainWindow *window);
     void removeWindow(MainWindow *window);
-	static QTerminalApp *Instance(int &argc, char **argv);
-	static QTerminalApp *Instance();
+    static QTerminalApp *Instance(int &argc, char **argv);
+    static QTerminalApp *Instance();
+    QString &getWorkingDirectory();
+    void setWorkingDirectory(const QString &wd);
+
 
 private:
-	QList<MainWindow *> m_windowList;
-	static QTerminalApp *m_instance;
-	QTerminalApp(int &argc, char **argv);
-	~QTerminalApp(){};
+    QString m_workDir;
+    QList<MainWindow *> m_windowList;
+    static QTerminalApp *m_instance;
+    QTerminalApp(int &argc, char **argv);
+    ~QTerminalApp(){};
 };
 
 template <class T> T* findParent(QObject *child)

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -61,26 +61,17 @@ TermWidgetHolder * TabWidget::terminalHolder()
     return reinterpret_cast<TermWidgetHolder*>(widget(currentIndex()));
 }
 
-void TabWidget::setWorkDirectory(const QString& dir)
-{
-    this->work_dir = dir;
-}
 
-int TabWidget::addNewTab(const QString & shell_program)
+int TabWidget::addNewTab(TerminalConfig config)
 {
     tabNumerator++;
     QString label = QString(tr("Shell No. %1")).arg(tabNumerator);
 
     TermWidgetHolder *ch = terminalHolder();
-    QString cwd(work_dir);
-    if (Properties::Instance()->useCWD && ch)
-    {
-        cwd = ch->currentTerminal()->impl()->workingDirectory();
-        if (cwd.isEmpty())
-            cwd = work_dir;
-    }
+    if (ch)
+        config.provideCurrentDirectory(ch->currentTerminal()->impl()->workingDirectory());
 
-    TermWidgetHolder *console = new TermWidgetHolder(cwd, shell_program, this);
+    TermWidgetHolder *console = new TermWidgetHolder(config, this);
     console->setWindowTitle(label);
     connect(console, SIGNAL(finished()), SLOT(removeFinished()));
     connect(console, SIGNAL(lastTerminalClosed()), this, SLOT(removeFinished()));
@@ -233,7 +224,10 @@ bool TabWidget::eventFilter(QObject *obj, QEvent *event)
         // clicks on free space - open new tab
         int index = tabBar()->tabAt(e->pos());
         if (index == -1)
-            addNewTab();
+        {
+            TerminalConfig defaultConfig;
+            addNewTab(defaultConfig);
+        }
         else
             renameSession(index);
         return true;
@@ -429,7 +423,8 @@ void TabWidget::loadSession()
 
 void TabWidget::preset2Horizontal()
 {
-    int ix = TabWidget::addNewTab();
+    TerminalConfig defaultConfig;
+    int ix = TabWidget::addNewTab(defaultConfig);
     TermWidgetHolder* term = reinterpret_cast<TermWidgetHolder*>(widget(ix));
     term->splitHorizontal(term->currentTerminal());
     // switch to the 1st terminal
@@ -438,7 +433,8 @@ void TabWidget::preset2Horizontal()
 
 void TabWidget::preset2Vertical()
 {
-    int ix = TabWidget::addNewTab();
+    TerminalConfig defaultConfig;
+    int ix = TabWidget::addNewTab(defaultConfig);
     TermWidgetHolder* term = reinterpret_cast<TermWidgetHolder*>(widget(ix));
     term->splitVertical(term->currentTerminal());
     // switch to the 1st terminal
@@ -447,7 +443,8 @@ void TabWidget::preset2Vertical()
 
 void TabWidget::preset4Terminals()
 {
-    int ix = TabWidget::addNewTab();
+    TerminalConfig defaultConfig;
+    int ix = TabWidget::addNewTab(defaultConfig);
     TermWidgetHolder* term = reinterpret_cast<TermWidgetHolder*>(widget(ix));
     term->splitVertical(term->currentTerminal());
     term->splitHorizontal(term->currentTerminal());

--- a/src/tabwidget.h
+++ b/src/tabwidget.h
@@ -23,7 +23,7 @@
 #include <QMap>
 #include <QAction>
 
-
+#include "terminalconfig.h"
 #include "properties.h"
 
 class TermWidgetHolder;
@@ -42,7 +42,7 @@ public:
     void showHideTabBar();
 
 public slots:
-    int addNewTab(const QString& shell_program = QString());
+    int addNewTab(TerminalConfig cfg);
     void removeTab(int);
     void removeCurrentTab();
     int switchToRight();
@@ -52,7 +52,6 @@ public slots:
     void moveRight();
     void renameSession(int);
     void renameCurrentSession();
-    void setWorkDirectory(const QString&);
 
     void switchNextSubterminal();
     void switchPrevSubterminal();
@@ -102,7 +101,6 @@ protected slots:
 
 private:
     int tabNumerator;
-    QString work_dir;
     /* re-order naming of the tabs then removeCurrentTab() */
     void renameTabsAfterRemove();
 };

--- a/src/tabwidget.h
+++ b/src/tabwidget.h
@@ -23,6 +23,11 @@
 #include <QMap>
 #include <QAction>
 
+#ifdef HAVE_QDBUS
+    #include <QtDBus/QtDBus>
+    #include "dbusaddressable.h"
+#endif
+
 #include "terminalconfig.h"
 #include "properties.h"
 

--- a/src/terminalconfig.cpp
+++ b/src/terminalconfig.cpp
@@ -64,3 +64,42 @@ void TerminalConfig::provideCurrentDirectory(const QString &val)
 }
 
 
+
+#if HAVE_QDBUS
+
+#define DBUS_ARG_WORKDIR "workingDirectory"
+#define DBUS_ARG_SHELL "shell"
+
+TerminalConfig TerminalConfig::fromDbus(const QHash<QString,QVariant> &termArgsConst, TermWidget *toSplit)
+{
+    QHash<QString,QVariant> termArgs(termArgsConst);
+    if (toSplit != NULL && !termArgs.contains(DBUS_ARG_WORKDIR))
+    {
+        termArgs[DBUS_ARG_WORKDIR] = QVariant(toSplit->impl()->workingDirectory());
+    }
+    return TerminalConfig::fromDbus(termArgs);
+}
+
+static QString variantToString(QVariant variant, QString &defaultVal)
+{
+    if (variant.type() == QVariant::String)
+        return qvariant_cast<QString>(variant);
+    return defaultVal;
+}
+
+TerminalConfig TerminalConfig::fromDbus(const QHash<QString,QVariant> &termArgs)
+{
+    QString wdir("");
+    QString shell(Properties::Instance()->shell);
+    if (termArgs.contains(DBUS_ARG_WORKDIR))
+    {
+        wdir = variantToString(termArgs[DBUS_ARG_WORKDIR], wdir);
+    }
+    if (termArgs.contains(DBUS_ARG_SHELL)) {
+        shell = variantToString(termArgs[DBUS_ARG_SHELL], shell);
+    }
+    return TerminalConfig(wdir, shell);
+}
+
+#endif
+

--- a/src/terminalconfig.cpp
+++ b/src/terminalconfig.cpp
@@ -1,0 +1,66 @@
+
+
+#include <QHash>
+#include <QString>
+
+#include "qterminalapp.h"
+#include "terminalconfig.h"
+#include "properties.h"
+#include "termwidget.h"
+
+TerminalConfig::TerminalConfig(const QString & wdir, const QString & shell)
+{
+    m_workingDirectory = wdir;
+    m_shell = shell;
+}
+
+TerminalConfig::TerminalConfig()
+{
+}
+
+TerminalConfig::TerminalConfig(const TerminalConfig &cfg)
+    : m_currentDirectory(cfg.m_currentDirectory),
+      m_workingDirectory(cfg.m_workingDirectory),
+      m_shell(cfg.m_shell) {}
+
+QString TerminalConfig::getWorkingDirectory()
+{
+    if (!m_workingDirectory.isEmpty())
+        return m_workingDirectory;
+    if (Properties::Instance()->useCWD && !m_currentDirectory.isEmpty())
+        return m_currentDirectory;
+    return QTerminalApp::Instance()->getWorkingDirectory();
+}
+
+QString TerminalConfig::getShell()
+{
+    if (!m_shell.isEmpty())
+        return m_shell;
+    if (!Properties::Instance()->shell.isEmpty())
+        return Properties::Instance()->shell;
+    QByteArray envShell = qgetenv("SHELL");
+    if (envShell.constData() != NULL)
+    {
+        QString shellString = QString(envShell);
+        if (!shellString.isEmpty())
+            return shellString;
+    }
+    return QString();
+}
+
+void TerminalConfig::setWorkingDirectory(const QString &val)
+{
+    m_workingDirectory = val;
+}
+
+void TerminalConfig::setShell(const QString &val)
+{
+    m_shell = val;
+}
+
+void TerminalConfig::provideCurrentDirectory(const QString &val)
+{
+    m_currentDirectory = val;
+}
+
+

--- a/src/terminalconfig.h
+++ b/src/terminalconfig.h
@@ -22,6 +22,11 @@ class TerminalConfig
         void setShell(const QString &val);
         void provideCurrentDirectory(const QString &val);
 
+        #ifdef HAVE_QDBUS
+        static TerminalConfig fromDbus(const QHash<QString,QVariant> &termArgs);
+        static TerminalConfig fromDbus(const QHash<QString,QVariant> &termArgs, TermWidget *toSplit);
+        #endif
+
 
     private:
     	// True when 

--- a/src/terminalconfig.h
+++ b/src/terminalconfig.h
@@ -1,0 +1,33 @@
+
+#ifndef TERMINALCONFIG_H
+#define TERMINALCONFIG_H
+
+#include <QHash>
+#include <QString>
+#include <QVariant>
+
+class TermWidget;
+
+class TerminalConfig
+{
+    public:
+        TerminalConfig(const QString & wdir, const QString & shell);
+        TerminalConfig(const TerminalConfig &cfg);
+        TerminalConfig();
+
+        QString getWorkingDirectory();
+        QString getShell();
+
+        void setWorkingDirectory(const QString &val);
+        void setShell(const QString &val);
+        void provideCurrentDirectory(const QString &val);
+
+
+    private:
+    	// True when 
+    	QString m_currentDirectory;
+    	QString m_workingDirectory;
+        QString m_shell;
+};
+
+#endif

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -31,7 +31,7 @@
 static int TermWidgetCount = 0;
 
 
-TermWidgetImpl::TermWidgetImpl(const QString & wdir, const QString & shell, QWidget * parent)
+TermWidgetImpl::TermWidgetImpl(TerminalConfig &cfg, QWidget * parent)
     : QTermWidget(0, parent)
 {
     TermWidgetCount++;
@@ -45,17 +45,12 @@ TermWidgetImpl::TermWidgetImpl(const QString & wdir, const QString & shell, QWid
 
     setHistorySize(5000);
 
-    if (!wdir.isNull())
-        setWorkingDirectory(wdir);
+    setWorkingDirectory(cfg.getWorkingDirectory());
 
-    if (shell.isNull())
+    QString shell = cfg.getShell();
+    if (!shell.isEmpty())
     {
-        if (!Properties::Instance()->shell.isNull())
-            setShellProgram(Properties::Instance()->shell);
-    }
-    else
-    {
-        qDebug() << "Settings custom shell program:" << shell;
+        qDebug() << "Shell program:" << shell;
         QStringList parts = shell.split(QRegExp("\\s+"), QString::SkipEmptyParts);
         qDebug() << parts;
         setShellProgram(parts.at(0));
@@ -178,11 +173,11 @@ void TermWidgetImpl::activateUrl(const QUrl & url, bool fromContextMenu) {
     }
 }
 
-TermWidget::TermWidget(const QString & wdir, const QString & shell, QWidget * parent)
+TermWidget::TermWidget(TerminalConfig &cfg, QWidget * parent)
     : QWidget(parent)
 {
     m_border = palette().color(QPalette::Window);
-    m_term = new TermWidgetImpl(wdir, shell, this);
+    m_term = new TermWidgetImpl(cfg, this);
     setFocusProxy(m_term);
 
     m_layout = new QVBoxLayout;

--- a/src/termwidget.h
+++ b/src/termwidget.h
@@ -23,7 +23,7 @@
 #include "terminalconfig.h"
 
 #include <QAction>
-
+#include "dbusaddressable.h"
 
 class TermWidgetImpl : public QTermWidget
 {
@@ -51,7 +51,7 @@ class TermWidgetImpl : public QTermWidget
 };
 
 
-class TermWidget : public QWidget
+class TermWidget : public QWidget, public DBusAddressable
 {
     Q_OBJECT
 
@@ -66,6 +66,14 @@ class TermWidget : public QWidget
         QStringList availableKeyBindings() { return m_term->availableKeyBindings(); }
 
         TermWidgetImpl * impl() { return m_term; }
+
+        #ifdef HAVE_QDBUS
+        QDBusObjectPath splitHorizontal(const QHash<QString,QVariant> &termArgs);
+        QDBusObjectPath splitVertical(const QHash<QString,QVariant> &termArgs);
+        QDBusObjectPath getTab();
+        void sendText(const QString text);
+        void closeTerminal();
+        #endif
 
     signals:
         void finished();

--- a/src/termwidget.h
+++ b/src/termwidget.h
@@ -20,6 +20,7 @@
 #define TERMWIDGET_H
 
 #include <qtermwidget.h>
+#include "terminalconfig.h"
 
 #include <QAction>
 
@@ -32,7 +33,7 @@ class TermWidgetImpl : public QTermWidget
 
     public:
 
-        TermWidgetImpl(const QString & wdir, const QString & shell=QString(), QWidget * parent=0);
+        TermWidgetImpl(TerminalConfig &cfg, QWidget * parent=0);
         void propertiesChanged();
 
     signals:
@@ -59,7 +60,7 @@ class TermWidget : public QWidget
     QColor m_border;
 
     public:
-        TermWidget(const QString & wdir, const QString & shell=QString(), QWidget * parent=0);
+        TermWidget(TerminalConfig &cfg, QWidget * parent=0);
 
         void propertiesChanged(); 
         QStringList availableKeyBindings() { return m_term->availableKeyBindings(); }

--- a/src/termwidgetholder.cpp
+++ b/src/termwidgetholder.cpp
@@ -20,16 +20,16 @@
 #include <QSplitter>
 #include <QInputDialog>
 
+#include "qterminalapp.h"
+#include "mainwindow.h"
 #include "termwidgetholder.h"
 #include "termwidget.h"
 #include "properties.h"
 #include <assert.h>
 
 
-TermWidgetHolder::TermWidgetHolder(const QString & wdir, const QString & shell, QWidget * parent)
+TermWidgetHolder::TermWidgetHolder(TerminalConfig &config, QWidget * parent)
     : QWidget(parent),
-      m_wdir(wdir),
-      m_shell(shell),
       m_currentTerm(0)
 {
     setFocusPolicy(Qt::NoFocus);
@@ -39,7 +39,7 @@ TermWidgetHolder::TermWidgetHolder(const QString & wdir, const QString & shell, 
 
     QSplitter *s = new QSplitter(this);
     s->setFocusPolicy(Qt::NoFocus);
-    TermWidget *w = newTerm();
+    TermWidget *w = newTerm(config);
     s->addWidget(w);
     lay->addWidget(s);
 
@@ -119,11 +119,6 @@ TermWidget* TermWidgetHolder::currentTerminal()
     return m_currentTerm;
 }
 
-void TermWidgetHolder::setWDir(const QString & wdir)
-{
-    m_wdir = wdir;
-}
-
 void TermWidgetHolder::switchNextSubterminal()
 {
     // TODO/FIXME: merge switchPrevSubterminal with switchNextSubterminal
@@ -185,12 +180,14 @@ void TermWidgetHolder::propertiesChanged()
 
 void TermWidgetHolder::splitHorizontal(TermWidget * term)
 {
-    split(term, Qt::Vertical);
+    TerminalConfig defaultConfig;
+    split(term, Qt::Vertical, defaultConfig);
 }
 
 void TermWidgetHolder::splitVertical(TermWidget * term)
 {
-    split(term, Qt::Horizontal);
+    TerminalConfig defaultConfig;
+    split(term, Qt::Horizontal, defaultConfig);
 }
 
 void TermWidgetHolder::splitCollapse(TermWidget * term)
@@ -242,7 +239,7 @@ void TermWidgetHolder::splitCollapse(TermWidget * term)
         emit finished();
 }
 
-void TermWidgetHolder::split(TermWidget *term, Qt::Orientation orientation)
+TermWidget * TermWidgetHolder::split(TermWidget *term, Qt::Orientation orientation, TerminalConfig cfg)
 {
     QSplitter *parent = qobject_cast<QSplitter *>(term->parent());
     assert(parent);
@@ -257,16 +254,9 @@ void TermWidgetHolder::split(TermWidget *term, Qt::Orientation orientation)
     s->setFocusPolicy(Qt::NoFocus);
     s->insertWidget(0, term);
 
-    // wdir settings
-    QString wd(m_wdir);
-    if (Properties::Instance()->useCWD)
-    {
-        wd = term->impl()->workingDirectory();
-        if (wd.isEmpty())
-            wd = m_wdir;
-    }
-
-    TermWidget * w = newTerm(wd);
+    cfg.provideCurrentDirectory(term->impl()->workingDirectory());
+    
+    TermWidget * w = newTerm(cfg);
     s->insertWidget(1, w);
     s->setSizes(sizes);
 
@@ -274,19 +264,12 @@ void TermWidgetHolder::split(TermWidget *term, Qt::Orientation orientation)
     parent->setSizes(parentSizes);
 
     w->setFocus(Qt::OtherFocusReason);
+    return w;
 }
 
-TermWidget *TermWidgetHolder::newTerm(const QString & wdir, const QString & shell)
+TermWidget *TermWidgetHolder::newTerm(TerminalConfig &cfg)
 {
-    QString wd(wdir);
-    if (wd.isEmpty())
-        wd = m_wdir;
-
-    QString sh(shell);
-    if (shell.isEmpty())
-        sh = m_shell;
-
-    TermWidget *w = new TermWidget(wd, sh, this);
+    TermWidget *w = new TermWidget(cfg, this);
     // proxy signals
     connect(w, SIGNAL(renameSession()), this, SIGNAL(renameSession()));
     connect(w, SIGNAL(removeCurrentSession()), this, SIGNAL(lastTerminalClosed()));
@@ -339,3 +322,4 @@ void TermWidgetHolder::onTermTitleChanged(QString title, QString icon) const
     if (m_currentTerm == term)
         emit termTitleChanged(title, icon);
 }
+

--- a/src/termwidgetholder.h
+++ b/src/termwidgetholder.h
@@ -22,6 +22,7 @@
 #include <QWidget>
 #include "termwidget.h"
 #include "terminalconfig.h"
+#include "dbusaddressable.h"
 class QSplitter;
 
 
@@ -35,6 +36,9 @@ for TabWidget - with its signals and slots.
 Splitting and collapsing of TermWidgets is done here.
 */
 class TermWidgetHolder : public QWidget
+#ifdef HAVE_QDBUS
+    , public DBusAddressable
+#endif
 {
     Q_OBJECT
 
@@ -52,6 +56,13 @@ class TermWidgetHolder : public QWidget
 
         TermWidget* currentTerminal();
         TermWidget* split(TermWidget * term, Qt::Orientation orientation, TerminalConfig cfg);
+
+        #ifdef HAVE_QDBUS
+        QDBusObjectPath getActiveTerminal();
+        QList<QDBusObjectPath> getTerminals();
+        QDBusObjectPath getWindow();
+        void closeTab();
+        #endif
 
 
     public slots:

--- a/src/termwidgetholder.h
+++ b/src/termwidgetholder.h
@@ -21,6 +21,7 @@
 
 #include <QWidget>
 #include "termwidget.h"
+#include "terminalconfig.h"
 class QSplitter;
 
 
@@ -38,7 +39,7 @@ class TermWidgetHolder : public QWidget
     Q_OBJECT
 
     public:
-        TermWidgetHolder(const QString & wdir, const QString & shell=QString(), QWidget * parent=0);
+        TermWidgetHolder(TerminalConfig &cfg, QWidget * parent=0);
         ~TermWidgetHolder();
 
         void propertiesChanged();
@@ -50,12 +51,13 @@ class TermWidgetHolder : public QWidget
         void zoomOut(uint step);
 
         TermWidget* currentTerminal();
+        TermWidget* split(TermWidget * term, Qt::Orientation orientation, TerminalConfig cfg);
+
 
     public slots:
         void splitHorizontal(TermWidget * term);
         void splitVertical(TermWidget * term);
         void splitCollapse(TermWidget * term);
-        void setWDir(const QString & wdir);
         void switchNextSubterminal();
         void switchPrevSubterminal();
         void clearActiveTerminal();
@@ -68,12 +70,9 @@ class TermWidgetHolder : public QWidget
         void termTitleChanged(QString title, QString icon) const;
 
     private:
-        QString m_wdir;
-        QString m_shell;
         TermWidget * m_currentTerm;
 
-        void split(TermWidget * term, Qt::Orientation orientation);
-        TermWidget * newTerm(const QString & wdir=QString(), const QString & shell=QString());
+        TermWidget * newTerm(TerminalConfig &cfg);
 
     private slots:
         void setCurrentTerminal(TermWidget* term);


### PR DESCRIPTION
All competing terminals (Konsole, Gnome Terminal, Terminator) nowadays implement some kind of DBus integration.

This is very useful when integrating any kind of terminal work into development workflow, e.g. opening tabs instead of windows when using "Open Terminal here" or preserving developer environment in a script.

The proposed branch implements basic DBus integration. It's also optional -- while Linux Qt usually requires DBus, my concern was Mac builds.

The new tab/split/window methods accept a dict, which can be used to specify an override for the default shell and/or work directory and can be extended to more arguments without changing the API.

Here's the implemented interface, as rendered by D-Feet.

![qterminal-dbus](https://cloud.githubusercontent.com/assets/5209166/24044769/b7b84916-0b2d-11e7-9a2f-0de895cbffa8.png)
