### PR TITLE
Support custom QSS styles

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -123,6 +123,19 @@ int main(int argc, char *argv[])
     if (workdir.isEmpty())
         workdir = QDir::currentPath();
 
+    const QSettings settings;
+    const QFileInfo customStyle = QFileInfo(
+        QFileInfo(settings.fileName()).canonicalPath() +
+        "/style.qss"
+    );
+    if (customStyle.isFile() && customStyle.isReadable())
+    {
+        QFile style(customStyle.canonicalFilePath());
+        style.open(QFile::ReadOnly);
+        QString styleString = QLatin1String(style.readAll());
+        app->setStyleSheet(styleString);
+    }
+
     // icons
     /* setup our custom icon theme if there is no system theme (OS X, Windows) */
     if (QIcon::themeName().isEmpty())


### PR DESCRIPTION
This implements the ability to style QTerminal with QSS by placing style.qss into the configuration directory.

Here's an example of what QSS might do:
![qterminal-styles](https://cloud.githubusercontent.com/assets/5209166/24045498/60fa0ef4-0b30-11e7-8b79-850d8c0b73eb.png)
