### PR TITLE
New features: trim \n from pasted strings, confirm multiline pastes

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -423,6 +423,20 @@
             </property>
            </widget>
           </item>
+          <item row="3" column="0" colspan="3">
+           <widget class="QCheckBox" name="confirmMultilinePasteCheckBox">
+            <property name="text">
+             <string>Confirm multiline paste</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0" colspan="3">
+           <widget class="QCheckBox" name="trimPastedTrailingNewlinesCheckBox">
+            <property name="text">
+             <string>Trim trailing newlines in pasted text</string>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="2">
            <widget class="QSpinBox" name="historyLimitedTo">
             <property name="minimum">
@@ -436,7 +450,7 @@
             </property>
            </widget>
           </item>
-          <item row="7" column="1">
+          <item row="9" column="1">
            <spacer name="verticalSpacer_4">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -449,28 +463,28 @@
             </property>
            </spacer>
           </item>
-          <item row="6" column="0" colspan="3">
+          <item row="8" column="0" colspan="3">
            <widget class="QCheckBox" name="useCwdCheckBox">
             <property name="text">
              <string>Open new terminals in current working directory</string>
             </property>
            </widget>
           </item>
-          <item row="5" column="0" colspan="3">
+          <item row="7" column="0" colspan="3">
            <widget class="QCheckBox" name="saveSizeOnExitCheckBox">
             <property name="text">
              <string>Save Size when closing</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="0" colspan="3">
+          <item row="6" column="0" colspan="3">
            <widget class="QCheckBox" name="savePosOnExitCheckBox">
             <property name="text">
              <string>Save Position when closing</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="0" colspan="3">
+          <item row="5" column="0" colspan="3">
            <widget class="QCheckBox" name="askOnExitCheckBox">
             <property name="text">
              <string>Ask for confirmation when closing</string>

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -133,6 +133,9 @@ void Properties::loadSettings()
 
     changeWindowTitle = m_settings->value("ChangeWindowTitle", true).toBool();
     changeWindowIcon = m_settings->value("ChangeWindowIcon", true).toBool();
+
+    confirmMultilinePaste = m_settings->value("ConfirmMultilinePaste", false).toBool();
+    trimPastedTrailingNewlines = m_settings->value("TrimPastedTrailingNewlines", false).toBool();
 }
 
 void Properties::saveSettings()
@@ -213,6 +216,10 @@ void Properties::saveSettings()
 
     m_settings->setValue("ChangeWindowTitle", changeWindowTitle);
     m_settings->setValue("ChangeWindowIcon", changeWindowIcon);
+
+
+    m_settings->setValue("ConfirmMultilinePaste", confirmMultilinePaste);
+    m_settings->setValue("TrimPastedTrailingNewlines", trimPastedTrailingNewlines);
 }
 
 void Properties::migrate_settings()

--- a/src/properties.h
+++ b/src/properties.h
@@ -94,6 +94,9 @@ class Properties
         bool changeWindowTitle;
         bool changeWindowIcon;
 
+        bool confirmMultilinePaste;
+        bool trimPastedTrailingNewlines;
+
 
     private:
 

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -137,6 +137,10 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
 
     changeWindowTitleCheckBox->setChecked(Properties::Instance()->changeWindowTitle);
     changeWindowIconCheckBox->setChecked(Properties::Instance()->changeWindowIcon);
+
+    trimPastedTrailingNewlinesCheckBox->setChecked(Properties::Instance()->trimPastedTrailingNewlines);
+    confirmMultilinePasteCheckBox->setChecked(Properties::Instance()->confirmMultilinePaste);
+
 }
 
 
@@ -203,6 +207,9 @@ void PropertiesDialog::apply()
 
     Properties::Instance()->changeWindowTitle = changeWindowTitleCheckBox->isChecked();
     Properties::Instance()->changeWindowIcon = changeWindowIconCheckBox->isChecked();
+
+    Properties::Instance()->trimPastedTrailingNewlines = trimPastedTrailingNewlinesCheckBox->isChecked();
+    Properties::Instance()->confirmMultilinePaste = confirmMultilinePasteCheckBox->isChecked();
 
     emit propertiesChanged();
 }

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -20,6 +20,9 @@
 #include <QVBoxLayout>
 #include <QPainter>
 #include <QDesktopServices>
+#include <QMessageBox>
+#include <QAbstractButton>
+#include <QMouseEvent>
 #include <assert.h>
 
 #include "mainwindow.h"
@@ -178,6 +181,83 @@ void TermWidgetImpl::activateUrl(const QUrl & url, bool fromContextMenu) {
     }
 }
 
+void TermWidgetImpl::pasteSelection()
+{
+    paste(QClipboard::Selection);
+}
+
+void TermWidgetImpl::pasteClipboard()
+{
+    paste(QClipboard::Clipboard);
+}
+
+void TermWidgetImpl::paste(QClipboard::Mode mode)
+{
+    // Paste Clipboard by simulating keypress events
+    QString text = QApplication::clipboard()->text(mode);
+    if ( ! text.isEmpty() )
+    {
+        text.replace("\r\n", "\n");
+        text.replace('\n', '\r');
+        QString trimmedTrailingNl(text);
+        trimmedTrailingNl.replace(QRegExp("\\r+$"), "");
+        bool isMultiline = trimmedTrailingNl.contains('\r');
+        if (!isMultiline && Properties::Instance()->trimPastedTrailingNewlines)
+        {
+            text = trimmedTrailingNl;
+        }
+        if (Properties::Instance()->confirmMultilinePaste)
+        {
+            if (text.contains('\r') && Properties::Instance()->confirmMultilinePaste)
+            {
+                QMessageBox confirmation(this);
+                confirmation.setWindowTitle(tr("Paste multiline text"));
+                confirmation.setText(tr("Are you sure you want to paste this text?"));
+                confirmation.setDetailedText(text);
+                confirmation.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+                // Click "Show details..." to show those by default
+                foreach( QAbstractButton * btn, confirmation.buttons() )
+                {
+                    if (confirmation.buttonRole(btn) == QMessageBox::ActionRole && btn->text() == QMessageBox::tr("Show Details..."))
+                    {
+                        btn->clicked();
+                        break;
+                    }
+                }
+                confirmation.setDefaultButton(QMessageBox::Yes);
+                confirmation.exec();
+                if (confirmation.standardButton(confirmation.clickedButton()) != QMessageBox::Yes)
+                {
+                    return;
+                }
+            }
+        }
+        
+        /* TODO: Support bracketedPasteMode
+        if (bracketedPasteMode())
+        {
+            text.prepend("\e[200~");
+            text.append("\e[201~");
+        }*/
+        sendText(text);
+    }
+}
+
+bool TermWidget::eventFilter(QObject * obj, QEvent * ev)
+{
+    if (ev->type() == QEvent::MouseButtonPress)
+    {
+        QMouseEvent *mev = (QMouseEvent *)ev;
+        if ( mev->button() == Qt::MidButton )
+        {
+            impl()->pasteSelection();
+            return true;
+        }
+    }
+    return false;
+}
+
+
 TermWidget::TermWidget(const QString & wdir, const QString & shell, QWidget * parent)
     : QWidget(parent)
 {
@@ -189,6 +269,14 @@ TermWidget::TermWidget(const QString & wdir, const QString & shell, QWidget * pa
     setLayout(m_layout);
 
     m_layout->addWidget(m_term);
+    foreach (QObject *o, m_term->children())
+    {
+        // Find TerminalDisplay
+        if (!o->isWidgetType() || qobject_cast<QWidget*>(o)->isHidden())
+            continue;
+        o->installEventFilter(this);
+    }
+    
 
     propertiesChanged();
 

--- a/src/termwidget.h
+++ b/src/termwidget.h
@@ -21,6 +21,7 @@
 
 #include <qtermwidget.h>
 
+#include <QClipboard>
 #include <QAction>
 
 
@@ -34,6 +35,7 @@ class TermWidgetImpl : public QTermWidget
 
         TermWidgetImpl(const QString & wdir, const QString & shell=QString(), QWidget * parent=0);
         void propertiesChanged();
+        void paste(QClipboard::Mode mode);
 
     signals:
         void renameSession();
@@ -43,6 +45,8 @@ class TermWidgetImpl : public QTermWidget
         void zoomIn();
         void zoomOut();
         void zoomReset();
+        void pasteSelection();
+        void pasteClipboard();
 
     private slots:
         void customContextMenuCall(const QPoint & pos);
@@ -80,6 +84,7 @@ class TermWidget : public QWidget
 
     protected:
         void paintEvent (QPaintEvent * event);
+        bool eventFilter(QObject * obj, QEvent * evt) override;
 
     private slots:
         void term_termGetFocus();


### PR DESCRIPTION
This fixes few of my biggest pet peeves when using any terminal.

It implements 2 features:
1. Trimming trailing \n from pasted strings. 
2. Confirming multiline pastes, with a preview (in case those are still multiline after optional trimming). Usual Qt shortcuts (Enter, Esc, Space) work for the dialog, so it doesn't pull you out of the zone or from the keyboard.

Both features are optional, disabled by default, exposed via UI, and separate.

Rationale is, as follows:
1. Trimming trailing newlines makes triple left click to select a line actually useful in most apps (including, but not limited to terminal itself and browser). Even when editing texts, I found pasted newlines generally useless.
2. In addition to defense vs [paste attacks](http://thejh.net/misc/website-terminal-copy-paste), this allows you to not break your session by accidentally selecting something huge and pasting it. Same goes for confusing X `PRIMARY` buffer with X `CLIPBOARD` buffer.

![qterminal-multiline-paste](https://cloud.githubusercontent.com/assets/5209166/24051171/4e3508e8-0b42-11e7-973b-895c554acdc3.png)
