### PR TITLE
Restore filter actions

### DIFF
--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -130,6 +130,17 @@ void TermWidgetImpl::customContextMenuCall(const QPoint & pos)
     QMenu menu;
     QMap<QString, QAction*> actions = findParent<MainWindow>(this)->leaseActions();
 
+    QList<QAction*> extraActions = filterActions(pos);
+    for (auto& action : extraActions)
+    {
+        menu.addAction(action);
+    }
+
+    if (!actions.isEmpty())
+    {
+        menu.addSeparator();
+    }
+
     menu.addAction(actions[COPY_SELECTION]);
     menu.addAction(actions[PASTE_CLIPBOARD]);
     menu.addAction(actions[PASTE_SELECTION]);


### PR DESCRIPTION
Accidentally removed in https://github.com/lxde/qterminal/pull/256. Those were originally added in #276. In this PR I also fixed a bug - an extra separator if there are no extra filter actions.