### PR TITLE
DBus DropMode

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -289,5 +289,26 @@ QDBusObjectPath QTerminalApp::getActiveWindow()
     return qobject_cast<MainWindow*>(aw)->getDbusPath();
 }
 
+bool QTerminalApp::isDropMode() {
+  if (m_windowList.count() == 0) {
+    return false;
+  }
+  MainWindow *wnd = m_windowList.at(0);
+  return wnd->dropMode();
+}
+
+bool QTerminalApp::toggleDropdown() {
+  if (m_windowList.count() == 0) {
+    return false;
+  }
+  MainWindow *wnd = m_windowList.at(0);
+  if (!wnd->dropMode()) {
+    return false;
+  }
+  wnd->showHide();
+  return true;
+}
+
+
 #endif
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -627,8 +627,9 @@ void MainWindow::realign()
         geometry.moveCenter(desktop.center());
         // do not use 0 here - we need to calculate with potential panel on top
         geometry.setTop(desktop.top());
-
-        setGeometry(geometry);
+        if (geometry != this->geometry()) {
+          setGeometry(geometry);
+        }
     }
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -92,6 +92,9 @@ private:
     bool hasMultipleTabs();
     bool hasMultipleSubterminals();
 
+public slots:
+    void showHide();
+
 private slots:
     void on_consoleTabulator_currentChanged(int);
     void propertiesChanged();
@@ -105,7 +108,6 @@ private slots:
     void toggleMenu();
 
     void showFullscreen(bool fullscreen);
-    void showHide();
     void setKeepOpen(bool value);
     void find();
 

--- a/src/org.lxqt.QTerminal.Process.xml
+++ b/src/org.lxqt.QTerminal.Process.xml
@@ -12,6 +12,12 @@
     <method name="getActiveWindow">
       <arg name="window" type="o" direction="out"/>
     </method>
+    <method name="isDropMode">
+      <arg name="isDropMode" type="b" direction="out"/>
+    </method>
+    <method name="toggleDropdown">
+      <arg name="success" type="b" direction="out"/>
+    </method>
   </interface>
 </node>
 

--- a/src/qterminalapp.h
+++ b/src/qterminalapp.h
@@ -29,6 +29,8 @@ public:
     QList<QDBusObjectPath> getWindows();
     QDBusObjectPath newWindow(const QHash<QString,QVariant> &termArgs);
     QDBusObjectPath getActiveWindow();
+    bool isDropMode();
+    bool toggleDropdown();
     #endif
 
     static void cleanup();


### PR DESCRIPTION
Since Terminator completely broke on recent Ubuntu, I decided to switch to QTerminal drop mode as well as the primary terminal app.

Because drop mode Global Shortcut never worked for me on stock Unity, I've implemented a workaround via the existing DBus interface using Process->toggleDropdown(), which should be invoked via WM hotkey handler.

The PR also implements an ability to distinguish between "normal" and "drop mode" processes using Process->isDropMode()

In other changes, I've sneaked in a simple check for unchanged window geometry to prevent unnecessary redraws I've experienced on every visibility toggle.
