### PR TITLE
Fix action inconsistency when switching tabs

### DIFF
--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -307,6 +307,7 @@ int TabWidget::switchToRight()
         setCurrentIndex(next_pos);
     else
         setCurrentIndex(0);
+    findParent<MainWindow>(this)->updateDisabledActions();
     return currentIndex();
 }
 
@@ -317,6 +318,7 @@ int TabWidget::switchToLeft()
         setCurrentIndex(count() - 1);
     else
         setCurrentIndex(previous_pos);
+    findParent<MainWindow>(this)->updateDisabledActions();
     return currentIndex();
 }
 


### PR DESCRIPTION
Fixes an issue where navigation between panes doesn't work when switching between tabs.

Steps to reproduce the issue this PR fixes:
- Open QTerminal
- Split pane vertically using keyboard shortcuts.
- Ensure that navigation using keyboard shortcuts works
- Create a tab using keyboard shortcuts (assuming new tab has a single pane)
- Switch back to original tab using keyboard shortcuts
- Notice that navigation between panes no longer works