### PR TITLE
Update information on distribution package

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ To build run `make`, to install `make install` which accepts variable `DESTDIR` 
 
 ### Binary packages
 
-QTerminal is provided by all major Linux distributions like [Arch Linux](https://www.archlinux.org/packages/?q=qterminal), Debian (as of Debian stretch), Fedora and openSUSE (Tumbleweed only so far).
+QTerminal is provided by all major Linux distributions like [Arch Linux](https://www.archlinux.org/packages/?q=qterminal), Debian (as of Debian stretch), Fedora and openSUSE.
 Just use the distributions' package managers to search for string `qterminal`.


### PR DESCRIPTION
QTerminal is now in all supported versions of openSUSE.