### PR TITLE
Add maximum tab width and proper text eliding.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,8 @@ set(EXE_NAME qterminal)
 set(QTERM_SRC
     src/main.cpp
     src/mainwindow.cpp
+    src/tabbar.cpp
+    src/tabstyle.cpp
     src/tabwidget.cpp
     src/termwidget.cpp
     src/termwidgetholder.cpp
@@ -63,6 +65,8 @@ set(QTERM_SRC
 set(QTERM_MOC_SRC
     src/qterminalapp.h
     src/mainwindow.h
+    src/tabbar.h
+    src/tabstyle.h
     src/tabwidget.h
     src/termwidget.h
     src/termwidgetholder.h

--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -114,7 +114,7 @@
          </property>
         </widget>
        </item>
-       <item row="17" column="0">
+       <item row="18" column="0">
         <widget class="QLabel" name="label_9">
          <property name="text">
           <string>Start with preset:</string>
@@ -130,14 +130,14 @@
        <item row="5" column="1">
         <widget class="QComboBox" name="tabsPos_comboBox"/>
        </item>
-       <item row="9" column="0">
+       <item row="10" column="0">
         <widget class="QCheckBox" name="highlightCurrentCheckBox">
          <property name="text">
           <string>Show a border around the current terminal</string>
          </property>
         </widget>
        </item>
-       <item row="14" column="0">
+       <item row="15" column="0">
         <widget class="QLabel" name="label">
          <property name="text">
           <string>Terminal transparency</string>
@@ -147,7 +147,7 @@
          </property>
         </widget>
        </item>
-       <item row="13" column="0">
+       <item row="14" column="0">
         <widget class="QLabel" name="label_4">
          <property name="text">
           <string>Application transparency</string>
@@ -157,7 +157,7 @@
          </property>
         </widget>
        </item>
-       <item row="17" column="1">
+       <item row="18" column="1">
         <widget class="QComboBox" name="terminalPresetComboBox">
          <item>
           <property name="text">
@@ -181,7 +181,7 @@
          </item>
         </widget>
        </item>
-       <item row="13" column="1">
+       <item row="14" column="1">
         <widget class="QSpinBox" name="appTransparencyBox">
          <property name="suffix">
           <string> %</string>
@@ -274,7 +274,7 @@
        <item row="6" column="1">
         <widget class="QComboBox" name="keybCursorShape_comboBox"/>
        </item>
-       <item row="14" column="1">
+       <item row="15" column="1">
         <widget class="QSpinBox" name="termTransparencyBox">
          <property name="suffix">
           <string> %</string>
@@ -300,7 +300,7 @@
          </property>
         </widget>
        </item>
-       <item row="17" column="0" colspan="2">
+       <item row="19" column="0" colspan="2">
         <spacer name="verticalSpacer_3">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -330,21 +330,21 @@
          </property>
         </widget>
        </item>
-       <item row="10" column="0" colspan="2">
+       <item row="11" column="0" colspan="2">
         <widget class="QCheckBox" name="changeWindowTitleCheckBox">
          <property name="text">
           <string>Change window title based on current terminal</string>
          </property>
         </widget>
        </item>
-       <item row="11" column="0" colspan="2">
+       <item row="12" column="0" colspan="2">
         <widget class="QCheckBox" name="changeWindowIconCheckBox">
          <property name="text">
           <string>Change window icon based on current terminal</string>
          </property>
         </widget>
        </item>
-       <item row="12" column="0" colspan="2">
+       <item row="13" column="0" colspan="2">
         <widget class="QCheckBox" name="enabledBidiSupportCheckBox">
          <property name="text">
           <string>Enable bi-directional text support</string>
@@ -358,7 +358,7 @@
          </property>
         </widget>
        </item>
-       <item row="16" column="1">
+       <item row="17" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
           <widget class="QLineEdit" name="backgroundImageLineEdit"/>
@@ -371,6 +371,26 @@
           </widget>
          </item>
         </layout>
+       </item>
+       <item row="9" column="0">
+        <widget class="QCheckBox" name="limitTabWidthCheckBox">
+         <property name="text">
+          <string>Limit tab width:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="1">
+        <widget class="QSpinBox" name="limitTabWidthSpinBox">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="suffix">
+          <string>px</string>
+         </property>
+         <property name="maximum">
+          <number>1000</number>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -806,6 +826,22 @@
     <hint type="destinationlabel">
      <x>147</x>
      <y>24</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>limitTabWidthCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>limitTabWidthSpinBox</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>350</x>
+     <y>275</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>618</x>
+     <y>275</y>
     </hint>
    </hints>
   </connection>

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -109,6 +109,10 @@ void Properties::loadSettings()
     hideTabBarWithOneTab = m_settings->value("HideTabBarWithOneTab", false).toBool();
     m_motionAfterPaste = m_settings->value("MotionAfterPaste", 0).toInt();
 
+    /* tab width limit */
+    limitTabWidth = m_settings->value("LimitTabWidth").toBool();
+    limitTabWidthValue = m_settings->value("LimitTabWidthValue", 300).toInt();
+
     /* toggles */
     borderless = m_settings->value("Borderless", false).toBool();
     tabBarless = m_settings->value("TabBarless", false).toBool();
@@ -198,6 +202,10 @@ void Properties::saveSettings()
     m_settings->setValue("KeyboardCursorShape", keyboardCursorShape);
     m_settings->setValue("HideTabBarWithOneTab", hideTabBarWithOneTab);
     m_settings->setValue("MotionAfterPaste", m_motionAfterPaste);
+
+    m_settings->setValue("LimitTabWidth", limitTabWidth);
+    m_settings->setValue("LimitTabWidthValue", limitTabWidthValue);
+
     m_settings->setValue("Borderless", borderless);
     m_settings->setValue("TabBarless", tabBarless);
     m_settings->setValue("MenuVisible", menuVisible);

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -110,8 +110,8 @@ void Properties::loadSettings()
     m_motionAfterPaste = m_settings->value("MotionAfterPaste", 0).toInt();
 
     /* tab width limit */
-    limitTabWidth = m_settings->value("LimitTabWidth").toBool();
-    limitTabWidthValue = m_settings->value("LimitTabWidthValue", 300).toInt();
+    limitTabWidth = m_settings->value("LimitTabWidth", true).toBool();
+    limitTabWidthValue = m_settings->value("LimitTabWidthValue", 500).toInt();
 
     /* toggles */
     borderless = m_settings->value("Borderless", false).toBool();

--- a/src/properties.h
+++ b/src/properties.h
@@ -68,6 +68,9 @@ class Properties
         bool hideTabBarWithOneTab;
         int m_motionAfterPaste;
 
+        bool limitTabWidth;
+        int limitTabWidthValue;
+
         bool borderless;
         bool tabBarless;
         bool menuVisible;

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -73,6 +73,10 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
     tabsPos_comboBox->addItems(tabsPosList);
     tabsPos_comboBox->setCurrentIndex(Properties::Instance()->tabsPos);
 
+    /* tab width */
+    limitTabWidthCheckBox->setChecked(Properties::Instance()->limitTabWidth);
+    limitTabWidthSpinBox->setValue(Properties::Instance()->limitTabWidthValue);
+
     /* keyboard cursor shape */
     QStringList keyboardCursorShapeList;
     keyboardCursorShapeList << tr("BlockCursor") << tr("UnderlineCursor") << tr("IBeamCursor");
@@ -183,6 +187,8 @@ void PropertiesDialog::apply()
 
     Properties::Instance()->scrollBarPos = scrollBarPos_comboBox->currentIndex();
     Properties::Instance()->tabsPos = tabsPos_comboBox->currentIndex();
+    Properties::Instance()->limitTabWidth = limitTabWidthCheckBox->isChecked();
+    Properties::Instance()->limitTabWidthValue = limitTabWidthSpinBox->value();
     Properties::Instance()->keyboardCursorShape = keybCursorShape_comboBox->currentIndex();
     Properties::Instance()->hideTabBarWithOneTab = hideTabBarCheckBox->isChecked();
     Properties::Instance()->menuVisible = showMenuCheckBox->isChecked();

--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -1,0 +1,33 @@
+/***************************************************************************
+ *   Copyright (C) 2017 by Nathan Osman                                    *
+ *   nathan@quickmediasolutions.com                                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ ***************************************************************************/
+
+#include "tabbar.h"
+#include "tabstyle.h"
+
+TabBar::TabBar(QWidget *parent)
+    : QTabBar(parent)
+{
+    setStyle(new TabStyle(this));
+}
+
+QSize TabBar::tabSizeHint(int index) const
+{
+    QSize size = QTabBar::tabSizeHint(index);
+    size.setWidth(300);
+    return size;
+}

--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -20,14 +20,37 @@
 #include "tabstyle.h"
 
 TabBar::TabBar(QWidget *parent)
-    : QTabBar(parent)
+    : QTabBar(parent),
+      mLimitWidth(false),
+      mLimitWidthValue(0)
 {
     setStyle(new TabStyle(this));
+}
+
+void TabBar::setLimitWidth(bool limitWidth)
+{
+    mLimitWidth = limitWidth;
+}
+
+void TabBar::setLimitWidthValue(int value)
+{
+    mLimitWidthValue = value;
+}
+
+void TabBar::updateWidth()
+{
+    // This seems to be the only way to trigger an update
+    setIconSize(iconSize());
 }
 
 QSize TabBar::tabSizeHint(int index) const
 {
     QSize size = QTabBar::tabSizeHint(index);
-    size.setWidth(300);
+
+    // If the width is limited, use that for the width hint
+    if (mLimitWidth) {
+        size.setWidth(mLimitWidthValue);
+    }
+
     return size;
 }

--- a/src/tabbar.h
+++ b/src/tabbar.h
@@ -1,0 +1,38 @@
+/***************************************************************************
+ *   Copyright (C) 2017 by Nathan Osman                                    *
+ *   nathan@quickmediasolutions.com                                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ ***************************************************************************/
+
+#ifndef TABBAR_H
+#define TABBAR_H
+
+#include <QSize>
+#include <QTabBar>
+
+class TabBar : public QTabBar
+{
+    Q_OBJECT
+
+public:
+
+    explicit TabBar(QWidget *parent);
+
+protected:
+
+    virtual QSize tabSizeHint(int index) const;
+};
+
+#endif // TABBAR_H

--- a/src/tabbar.h
+++ b/src/tabbar.h
@@ -30,9 +30,18 @@ public:
 
     explicit TabBar(QWidget *parent);
 
+    void setLimitWidth(bool limitWidth);
+    void setLimitWidthValue(int value);
+    void updateWidth();
+
 protected:
 
     virtual QSize tabSizeHint(int index) const;
+
+private:
+
+    bool mLimitWidth;
+    int mLimitWidthValue;
 };
 
 #endif // TABBAR_H

--- a/src/tabstyle.cpp
+++ b/src/tabstyle.cpp
@@ -16,6 +16,7 @@
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
  ***************************************************************************/
 
+#include <QPainter>
 #include <QPalette>
 #include <QRect>
 #include <QStyleOptionTab>
@@ -39,6 +40,20 @@ void TabStyle::drawControl(ControlElement element,
 
         // Determine the rect in which the text will be shown
         QRect rect = subElementRect(SE_TabBarTabText, option, widget);
+
+        // Draw the icon if specified
+        if (!tabOption->icon.isNull()) {
+
+            // Create a pixmap (with HiDPI support if enabled)
+            QPixmap tabIcon = tabOption->icon.pixmap(
+                        widget ? widget->window()->windowHandle() : nullptr,
+                        tabOption->iconSize);
+
+            // Draw the pixmap in the correct location
+            painter->drawPixmap(rect.left() - tabOption->iconSize.width() - 4,
+                                rect.center().y() - tabOption->iconSize.height() / 2,
+                                tabIcon);
+        }
 
         // Elide the text (truncate it with an ellipsis)
         QString elidedText = tabOption->fontMetrics.elidedText(tabOption->text,

--- a/src/tabstyle.cpp
+++ b/src/tabstyle.cpp
@@ -1,0 +1,60 @@
+/***************************************************************************
+ *   Copyright (C) 2017 by Nathan Osman                                    *
+ *   nathan@quickmediasolutions.com                                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ ***************************************************************************/
+
+#include <QPalette>
+#include <QRect>
+#include <QStyleOptionTab>
+
+#include "tabstyle.h"
+
+TabStyle::TabStyle(QObject *parent)
+{
+    setParent(parent);
+}
+
+void TabStyle::drawControl(ControlElement element,
+                           const QStyleOption *option,
+                           QPainter *painter,
+                           const QWidget *widget) const
+{
+    if (element == QStyle::CE_TabBarTabLabel) {
+
+        // Cast the options for the control to QStyleOptionTab
+        const QStyleOptionTab *tabOption = qstyleoption_cast<const QStyleOptionTab*>(option);
+
+        // Determine the rect in which the text will be shown
+        QRect rect = subElementRect(SE_TabBarTabText, option, widget);
+
+        // Elide the text (truncate it with an ellipsis)
+        QString elidedText = tabOption->fontMetrics.elidedText(tabOption->text,
+                                                               Qt::ElideRight,
+                                                               rect.width());
+
+        // Draw the final text
+        drawItemText(painter,
+                     rect,
+                     Qt::AlignVCenter,
+                     tabOption->palette,
+                     tabOption->state & State_Enabled,
+                     elidedText,
+                     QPalette::WindowText);
+
+    } else {
+        QProxyStyle::drawControl(element, option, painter, widget);
+    }
+}

--- a/src/tabstyle.cpp
+++ b/src/tabstyle.cpp
@@ -42,7 +42,7 @@ void TabStyle::drawControl(ControlElement element,
 
         // Elide the text (truncate it with an ellipsis)
         QString elidedText = tabOption->fontMetrics.elidedText(tabOption->text,
-                                                               Qt::ElideRight,
+                                                               Qt::ElideMiddle,
                                                                rect.width());
 
         // Draw the final text

--- a/src/tabstyle.h
+++ b/src/tabstyle.h
@@ -1,0 +1,38 @@
+/***************************************************************************
+ *   Copyright (C) 2017 by Nathan Osman                                    *
+ *   nathan@quickmediasolutions.com                                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ ***************************************************************************/
+
+#ifndef TABSTYLE_H
+#define TABSTYLE_H
+
+#include <QProxyStyle>
+
+class TabStyle : public QProxyStyle
+{
+    Q_OBJECT
+
+public:
+
+    explicit TabStyle(QObject *parent);
+
+    virtual void drawControl(ControlElement element,
+                             const QStyleOption *option,
+                             QPainter *painter,
+                             const QWidget *widget = Q_NULLPTR) const;
+};
+
+#endif // TABSTYLE_H

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -23,6 +23,7 @@
 
 #include "mainwindow.h"
 #include "termwidgetholder.h"
+#include "tabbar.h"
 #include "tabwidget.h"
 #include "config.h"
 #include "properties.h"

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -23,7 +23,6 @@
 
 #include "mainwindow.h"
 #include "termwidgetholder.h"
-#include "tabbar.h"
 #include "tabwidget.h"
 #include "config.h"
 #include "properties.h"
@@ -34,10 +33,10 @@
 #define TAB_CUSTOM_NAME_PROPERTY "custom_name"
 
 
-TabWidget::TabWidget(QWidget* parent) : QTabWidget(parent), tabNumerator(0)
+TabWidget::TabWidget(QWidget* parent) : QTabWidget(parent), tabNumerator(0), mTabBar(new TabBar(this))
 {
     // Insert our own tab bar which overrides tab width and eliding
-    setTabBar(new TabBar(this));
+    setTabBar(mTabBar);
 
     setFocusPolicy(Qt::NoFocus);
 
@@ -420,6 +419,11 @@ void TabWidget::propertiesChanged()
         console->propertiesChanged();
     }
     showHideTabBar();
+
+    // Update the tab widths
+    mTabBar->setLimitWidth(Properties::Instance()->limitTabWidth);
+    mTabBar->setLimitWidthValue(Properties::Instance()->limitTabWidthValue);
+    mTabBar->updateWidth();
 }
 
 void TabWidget::clearActiveTerminal()

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -23,6 +23,7 @@
 
 #include "mainwindow.h"
 #include "termwidgetholder.h"
+#include "tabbar.h"
 #include "tabwidget.h"
 #include "config.h"
 #include "properties.h"
@@ -35,6 +36,9 @@
 
 TabWidget::TabWidget(QWidget* parent) : QTabWidget(parent), tabNumerator(0)
 {
+    // Insert our own tab bar which overrides tab width and eliding
+    setTabBar(new TabBar(this));
+
     setFocusPolicy(Qt::NoFocus);
 
     /* On Mac OS X this will look similar to

--- a/src/tabwidget.h
+++ b/src/tabwidget.h
@@ -28,6 +28,7 @@
     #include "dbusaddressable.h"
 #endif
 
+#include "tabbar.h"
 #include "terminalconfig.h"
 #include "properties.h"
 
@@ -111,6 +112,8 @@ private:
     int tabNumerator;
     /* re-order naming of the tabs then removeCurrentTab() */
     void renameTabsAfterRemove();
+
+    TabBar *mTabBar;
 };
 
 #endif

--- a/src/tabwidget.h
+++ b/src/tabwidget.h
@@ -28,10 +28,10 @@
     #include "dbusaddressable.h"
 #endif
 
-#include "tabbar.h"
 #include "terminalconfig.h"
 #include "properties.h"
 
+class TabBar;
 class TermWidgetHolder;
 class QAction;
 class QActionGroup;


### PR DESCRIPTION
One of the things I noticed with qterminal is that the width of each tab changes based on the length of the text. This is fine if the current directory is `/tmp` but not if the current directory is `/usr/share/qtcreator/templates/wizards/classes/cpp`.

The tab becomes very wide and causes scrollbars to appear, making it difficult to navigate to other tabs with the mouse.

This pull request attempts to address that by limiting the maximum width of the tab to 300 pixels. Text that is longer than the tab width will be elided (an ellipsis shown at the end). The `TabBar` and `TabStyle` classes are necessary to correctly implement this behavior since the `QTabBar::setElideMode()` method doesn't work [due to a bug](https://bugreports.qt.io/browse/QTBUG-48994).

Here's a screenshot showing before and after:

![titlebar](https://user-images.githubusercontent.com/1253444/31757796-5be5472a-b45f-11e7-9b88-db2b0f41f5ad.png)

Note that the full path is still shown in the titlebar.
