### PR TITLE
Add RTL support checkbox

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -344,6 +344,13 @@
          </property>
         </widget>
        </item>
+       <item row="12" column="0" colspan="2">
+        <widget class="QCheckBox" name="enabledBidiSupportCheckBox">
+         <property name="text">
+          <string>Enable bi-directional text support</string>
+         </property>
+        </widget>
+       </item>
        <item row="15" column="0">
         <widget class="QLabel" name="label_13">
          <property name="text">
@@ -727,6 +734,7 @@
   <tabstop>highlightCurrentCheckBox</tabstop>
   <tabstop>changeWindowTitleCheckBox</tabstop>
   <tabstop>changeWindowIconCheckBox</tabstop>
+  <tabstop>enableBidiCheckBox</tabstop>
   <tabstop>appTransparencyBox</tabstop>
   <tabstop>termTransparencyBox</tabstop>
   <tabstop>backgroundImageLineEdit</tabstop>

--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -114,7 +114,7 @@
          </property>
         </widget>
        </item>
-       <item row="16" column="0">
+       <item row="17" column="0">
         <widget class="QLabel" name="label_9">
          <property name="text">
           <string>Start with preset:</string>
@@ -137,7 +137,7 @@
          </property>
         </widget>
        </item>
-       <item row="13" column="0">
+       <item row="14" column="0">
         <widget class="QLabel" name="label">
          <property name="text">
           <string>Terminal transparency</string>
@@ -147,7 +147,7 @@
          </property>
         </widget>
        </item>
-       <item row="12" column="0">
+       <item row="13" column="0">
         <widget class="QLabel" name="label_4">
          <property name="text">
           <string>Application transparency</string>
@@ -157,7 +157,7 @@
          </property>
         </widget>
        </item>
-       <item row="16" column="1">
+       <item row="17" column="1">
         <widget class="QComboBox" name="terminalPresetComboBox">
          <item>
           <property name="text">
@@ -181,7 +181,7 @@
          </item>
         </widget>
        </item>
-       <item row="12" column="1">
+       <item row="13" column="1">
         <widget class="QSpinBox" name="appTransparencyBox">
          <property name="suffix">
           <string> %</string>
@@ -274,7 +274,7 @@
        <item row="6" column="1">
         <widget class="QComboBox" name="keybCursorShape_comboBox"/>
        </item>
-       <item row="13" column="1">
+       <item row="14" column="1">
         <widget class="QSpinBox" name="termTransparencyBox">
          <property name="suffix">
           <string> %</string>
@@ -351,14 +351,14 @@
          </property>
         </widget>
        </item>
-       <item row="15" column="0">
+       <item row="16" column="0">
         <widget class="QLabel" name="label_13">
          <property name="text">
           <string>Background image:</string>
          </property>
         </widget>
        </item>
-       <item row="15" column="1">
+       <item row="16" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
           <widget class="QLineEdit" name="backgroundImageLineEdit"/>
@@ -734,7 +734,7 @@
   <tabstop>highlightCurrentCheckBox</tabstop>
   <tabstop>changeWindowTitleCheckBox</tabstop>
   <tabstop>changeWindowIconCheckBox</tabstop>
-  <tabstop>enableBidiCheckBox</tabstop>
+  <tabstop>enabledBidiSupportCheckBox</tabstop>
   <tabstop>appTransparencyBox</tabstop>
   <tabstop>termTransparencyBox</tabstop>
   <tabstop>backgroundImageLineEdit</tabstop>

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -136,6 +136,7 @@ void Properties::loadSettings()
 
     changeWindowTitle = m_settings->value("ChangeWindowTitle", true).toBool();
     changeWindowIcon = m_settings->value("ChangeWindowIcon", true).toBool();
+    enabledBidiSupport = m_settings->value("enabledBidiSupport", false).toBool();
 
     confirmMultilinePaste = m_settings->value("ConfirmMultilinePaste", false).toBool();
     trimPastedTrailingNewlines = m_settings->value("TrimPastedTrailingNewlines", false).toBool();
@@ -222,6 +223,7 @@ void Properties::saveSettings()
 
     m_settings->setValue("ChangeWindowTitle", changeWindowTitle);
     m_settings->setValue("ChangeWindowIcon", changeWindowIcon);
+    m_settings->setValue("enabledBidiSupport", enabledBidiSupport);
 
 
     m_settings->setValue("ConfirmMultilinePaste", confirmMultilinePaste);

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -136,7 +136,7 @@ void Properties::loadSettings()
 
     changeWindowTitle = m_settings->value("ChangeWindowTitle", true).toBool();
     changeWindowIcon = m_settings->value("ChangeWindowIcon", true).toBool();
-    enabledBidiSupport = m_settings->value("enabledBidiSupport", false).toBool();
+    enabledBidiSupport = m_settings->value("enabledBidiSupport", true).toBool();
 
     confirmMultilinePaste = m_settings->value("ConfirmMultilinePaste", false).toBool();
     trimPastedTrailingNewlines = m_settings->value("TrimPastedTrailingNewlines", false).toBool();

--- a/src/properties.h
+++ b/src/properties.h
@@ -93,6 +93,7 @@ class Properties
 
         bool changeWindowTitle;
         bool changeWindowIcon;
+        bool enabledBidiSupport;
 
         bool confirmMultilinePaste;
         bool trimPastedTrailingNewlines;

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -137,6 +137,7 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
 
     changeWindowTitleCheckBox->setChecked(Properties::Instance()->changeWindowTitle);
     changeWindowIconCheckBox->setChecked(Properties::Instance()->changeWindowIcon);
+    enabledBidiSupportCheckBox->setChecked(Properties::Instance()->enabledBidiSupport);
 
     trimPastedTrailingNewlinesCheckBox->setChecked(Properties::Instance()->trimPastedTrailingNewlines);
     confirmMultilinePasteCheckBox->setChecked(Properties::Instance()->confirmMultilinePaste);
@@ -207,6 +208,7 @@ void PropertiesDialog::apply()
 
     Properties::Instance()->changeWindowTitle = changeWindowTitleCheckBox->isChecked();
     Properties::Instance()->changeWindowIcon = changeWindowIconCheckBox->isChecked();
+    Properties::Instance()->enabledBidiSupport = enabledBidiSupportCheckBox->isChecked();
 
     Properties::Instance()->trimPastedTrailingNewlines = trimPastedTrailingNewlinesCheckBox->isChecked();
     Properties::Instance()->confirmMultilinePaste = confirmMultilinePasteCheckBox->isChecked();

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -99,6 +99,7 @@ void TermWidgetImpl::propertiesChanged()
     setKeyBindings(Properties::Instance()->emulation);
     setTerminalOpacity(1.0 - Properties::Instance()->termTransparency/100.0);
     setTerminalBackgroundImage(Properties::Instance()->backgroundImage);
+    setBidiEnabled(Properties::Instance()->enabledBidiSupport);
 
     /* be consequent with qtermwidget.h here */
     switch(Properties::Instance()->scrollBarPos) {


### PR DESCRIPTION
This adds a checkbox in the settings (appearance section) for enabling bidi support.
Must be done (and depend on) after lxde/qtermwidget#155 land.

Fixes #98