### PR TITLE
Fix a typo in qterminal_drop.desktop

### DIFF
--- a/qterminal_drop.desktop
+++ b/qterminal_drop.desktop
@@ -59,6 +59,6 @@ Comment[el]=Ένας αναπτυσσόμενος προσομοιωτής τε�
 Comment[lt]=Išskleidžiamasis terminalo emuliatorius.
 Comment[pt]=Um emulador de terminal suspenso.
 Comment[pt_BR]=Um emulador de terminal suspenso.
-Comment[ru]=Вападающий эмулятор терминала.
+Comment[ru]=Выпадающий эмулятор терминала.
 Comment[ja]=ドロップダウン式　ターミナルエミュレータ
 


### PR DESCRIPTION
Comment[ru] in qterminal_drop.desktop has a typo. Fix it.