### PR TITLE
Make tab closing button configurable

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -114,7 +114,7 @@
          </property>
         </widget>
        </item>
-       <item row="18" column="0">
+       <item row="19" column="0">
         <widget class="QLabel" name="label_9">
          <property name="text">
           <string>Start with preset:</string>
@@ -137,7 +137,7 @@
          </property>
         </widget>
        </item>
-       <item row="16" column="0">
+       <item row="17" column="0">
         <widget class="QLabel" name="label">
          <property name="text">
           <string>Terminal transparency</string>
@@ -147,7 +147,7 @@
          </property>
         </widget>
        </item>
-       <item row="15" column="0">
+       <item row="16" column="0">
         <widget class="QLabel" name="label_4">
          <property name="text">
           <string>Application transparency</string>
@@ -157,7 +157,7 @@
          </property>
         </widget>
        </item>
-       <item row="18" column="1">
+       <item row="19" column="1">
         <widget class="QComboBox" name="terminalPresetComboBox">
          <item>
           <property name="text">
@@ -181,7 +181,7 @@
          </item>
         </widget>
        </item>
-       <item row="15" column="1">
+       <item row="16" column="1">
         <widget class="QSpinBox" name="appTransparencyBox">
          <property name="suffix">
           <string> %</string>
@@ -274,7 +274,7 @@
        <item row="6" column="1">
         <widget class="QComboBox" name="keybCursorShape_comboBox"/>
        </item>
-       <item row="16" column="1">
+       <item row="17" column="1">
         <widget class="QSpinBox" name="termTransparencyBox">
          <property name="suffix">
           <string> %</string>
@@ -300,7 +300,7 @@
          </property>
         </widget>
        </item>
-       <item row="19" column="0" colspan="2">
+       <item row="20" column="0" colspan="2">
         <spacer name="verticalSpacer_3">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -330,35 +330,35 @@
          </property>
         </widget>
        </item>
-       <item row="11" column="0" colspan="2">
+       <item row="12" column="0" colspan="2">
         <widget class="QCheckBox" name="changeWindowTitleCheckBox">
          <property name="text">
           <string>Change window title based on current terminal</string>
          </property>
         </widget>
        </item>
-       <item row="12" column="0" colspan="2">
+       <item row="13" column="0" colspan="2">
         <widget class="QCheckBox" name="changeWindowIconCheckBox">
          <property name="text">
           <string>Change window icon based on current terminal</string>
          </property>
         </widget>
        </item>
-       <item row="14" column="0" colspan="2">
+       <item row="15" column="0" colspan="2">
         <widget class="QCheckBox" name="enabledBidiSupportCheckBox">
          <property name="text">
           <string>Enable bi-directional text support</string>
          </property>
         </widget>
        </item>
-       <item row="17" column="0">
+       <item row="18" column="0">
         <widget class="QLabel" name="label_13">
          <property name="text">
           <string>Background image:</string>
          </property>
         </widget>
        </item>
-       <item row="17" column="1">
+       <item row="18" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
           <widget class="QLineEdit" name="backgroundImageLineEdit"/>
@@ -372,7 +372,7 @@
          </item>
         </layout>
        </item>
-       <item row="13" column="0">
+       <item row="14" column="0">
         <widget class="QCheckBox" name="showTerminalSizeHintCheckBox">
          <property name="text">
           <string>Show terminal size on resize</string>
@@ -396,6 +396,16 @@
          </property>
          <property name="maximum">
           <number>1000</number>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="0">
+        <widget class="QCheckBox" name="closeTabButtonCheckBox">
+         <property name="text">
+          <string>Show close button on each tab</string>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
          </property>
         </widget>
        </item>

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -113,6 +113,7 @@ void Properties::loadSettings()
     /* tab width limit */
     limitTabWidth = m_settings->value("LimitTabWidth", true).toBool();
     limitTabWidthValue = m_settings->value("LimitTabWidthValue", 500).toInt();
+    showCloseTabButton = m_settings->value("ShowCloseTabButton", true).toBool();
 
     /* toggles */
     borderless = m_settings->value("Borderless", false).toBool();
@@ -208,6 +209,7 @@ void Properties::saveSettings()
 
     m_settings->setValue("LimitTabWidth", limitTabWidth);
     m_settings->setValue("LimitTabWidthValue", limitTabWidthValue);
+    m_settings->setValue("ShowCloseTabButton", showCloseTabButton);
 
     m_settings->setValue("Borderless", borderless);
     m_settings->setValue("TabBarless", tabBarless);

--- a/src/properties.h
+++ b/src/properties.h
@@ -72,6 +72,8 @@ class Properties
         bool limitTabWidth;
         int limitTabWidthValue;
 
+        bool showCloseTabButton;
+
         bool borderless;
         bool tabBarless;
         bool menuVisible;

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -76,6 +76,7 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
     /* tab width */
     limitTabWidthCheckBox->setChecked(Properties::Instance()->limitTabWidth);
     limitTabWidthSpinBox->setValue(Properties::Instance()->limitTabWidthValue);
+    closeTabButtonCheckBox->setChecked(Properties::Instance()->showCloseTabButton);
 
     /* keyboard cursor shape */
     QStringList keyboardCursorShapeList;
@@ -193,6 +194,7 @@ void PropertiesDialog::apply()
     Properties::Instance()->limitTabWidth = limitTabWidthCheckBox->isChecked();
     Properties::Instance()->limitTabWidthValue = limitTabWidthSpinBox->value();
     Properties::Instance()->keyboardCursorShape = keybCursorShape_comboBox->currentIndex();
+    Properties::Instance()->showCloseTabButton = closeTabButtonCheckBox->isChecked();
     Properties::Instance()->hideTabBarWithOneTab = hideTabBarCheckBox->isChecked();
     Properties::Instance()->menuVisible = showMenuCheckBox->isChecked();
     Properties::Instance()->m_motionAfterPaste = motionAfterPasting_comboBox->currentIndex();

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -49,7 +49,7 @@ TabWidget::TabWidget(QWidget* parent) : QTabWidget(parent), tabNumerator(0), mTa
 
     tabBar()->setUsesScrollButtons(true);
 
-    setTabsClosable(true);
+    setTabsClosable(Properties::Instance()->showCloseTabButton);
     setMovable(true);
     setUsesScrollButtons(true);
 
@@ -420,6 +420,8 @@ void TabWidget::propertiesChanged()
         console->propertiesChanged();
     }
     showHideTabBar();
+
+    setTabsClosable(Properties::Instance()->showCloseTabButton);
 
     // Update the tab widths
     mTabBar->setLimitWidth(Properties::Instance()->limitTabWidth);


### PR DESCRIPTION
This adds a property to switch on/off the tab closing buttons. The
default is on. With the hidden button, the space consumed by the tab is
slightly smaller.