### PR TITLE
Fixes tabAt() when tabBar is not at north position

### DIFF
--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -221,7 +221,7 @@ void TabWidget::contextMenuEvent(QContextMenuEvent *event)
     rename->setShortcut(actions[RENAME_SESSION]->shortcut());
     rename->blockSignals(true);
 
-    int tabIndex = tabBar()->tabAt(event->pos());
+    int tabIndex = tabBar()->tabAt(tabBar()->mapFrom(this,event->pos()));
     QAction *action = menu.exec(event->globalPos());
     if (action == close) {
         emit tabCloseRequested(tabIndex);


### PR DESCRIPTION
When renaming a tab with the context menu when the tabBar is not
at the north position, the tabAt was returning -1 due to wrongly
calculated postition for tabAt(). This is now fixed.
See https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=224718
and https://bugreports.qt.io/browse/QTBUG-16536