### PR TITLE
Fix terminal menubar

### DIFF
--- a/src/forms/qterminal.ui
+++ b/src/forms/qterminal.ui
@@ -13,9 +13,6 @@
   <property name="windowTitle">
    <string>MainWindow</string>
   </property>
-  <property name="autoFillBackground">
-   <bool>true</bool>
-  </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QGridLayout">
     <property name="leftMargin">
@@ -56,9 +53,6 @@
      <width>600</width>
      <height>26</height>
     </rect>
-   </property>
-   <property name="autoFillBackground">
-    <bool>true</bool>
    </property>
    <widget class="QMenu" name="menu_File">
     <property name="title">

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -66,7 +66,11 @@ MainWindow::MainWindow(TerminalConfig &cfg,
     registerAdapter<WindowAdaptor, MainWindow>(this);
 #endif
     QTerminalApp::Instance()->addWindow(this);
+    // We want terminal translucency...
     setAttribute(Qt::WA_TranslucentBackground);
+    // ... but neither a fully transparent nor a flat menubar
+    // with styles that have translucency and/or gradient.
+    setAttribute(Qt::WA_NoSystemBackground, false);
     setAttribute(Qt::WA_DeleteOnClose);
 
     setupUi(this);


### PR DESCRIPTION
Setting `autoFillBackground` to `true`, to prevent a fully transparent menubar with styles that have translucency, was a bad idea (of mine) because it presupposed a flat background, while styles like Oxygen, Kvantum and QtCurve can have gradient for background. Instead, setting `WA_NoSystemBackground` to `false` fixes both issues and allows terminal translucency with compositing.