### PR TITLE
Make active tab text bold to make it more visible

### DIFF
--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -25,6 +25,7 @@ TabBar::TabBar(QWidget *parent)
       mLimitWidthValue(0)
 {
     setStyle(new TabStyle(this));
+    setStyleSheet("QTabBar::tab:selected { font-weight: bold; }");
 }
 
 void TabBar::setLimitWidth(bool limitWidth)


### PR DESCRIPTION
This partially addresses issue #356. The active tab is looking almost
the same as an inactive one. This probably depends on system theme
settings or maybe is platform dependent.

The styling can be changed by either external stylesheet or an "in-line"
via the QWidget::styleSheet property.

This patch adds a simple in-line styleshee to change the active tab text
to bold. This is IMHO sufficient to recognize the active tab immediatelly,
further refinements are possible (eg. configurable color etc.)