### PR TITLE
Convert connect to the new syntax

### DIFF
--- a/src/bookmarkswidget.cpp
+++ b/src/bookmarkswidget.cpp
@@ -370,8 +370,8 @@ BookmarksWidget::BookmarksWidget(QWidget *parent)
     treeView->setModel(m_model);
     treeView->header()->hide();
 
-    connect(treeView, SIGNAL(doubleClicked(QModelIndex)),
-            this, SLOT(handleCommand(QModelIndex)));
+    connect(treeView, &QTreeView::doubleClicked,
+            this, &BookmarksWidget::handleCommand);
 }
 
 BookmarksWidget::~BookmarksWidget()

--- a/src/fontdialog.cpp
+++ b/src/fontdialog.cpp
@@ -32,12 +32,12 @@ FontDialog::FontDialog(const QFont &f)
 
     sizeSpinBox->setValue(f.pointSize());
 
-    setFontSample();
+    setFontSample(f);
 
-    connect(fontComboBox, SIGNAL(currentFontChanged(QFont)),
-            this, SLOT(setFontSample()));
-    connect(sizeSpinBox, SIGNAL(valueChanged(int)),
-            this, SLOT(setFontSample()));
+    connect(fontComboBox, &QFontComboBox::currentFontChanged,
+            this, &FontDialog::setFontSample);
+    connect(sizeSpinBox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+            this, &FontDialog::setFontSize);
 }
 
 QFont FontDialog::getFont()
@@ -47,9 +47,16 @@ QFont FontDialog::getFont()
     return f;
 }
 
-void FontDialog::setFontSample()
+void FontDialog::setFontSample(const QFont &f)
 {
-    QFont f = getFont();
+    previewLabel->setFont(f);
+    QString sample("%1 %2 pt");
+    previewLabel->setText(sample.arg(f.family()).arg(f.pointSize()));
+}
+
+void FontDialog::setFontSize()
+{
+    const QFont &f = getFont();
     previewLabel->setFont(f);
     QString sample("%1 %2 pt");
     previewLabel->setText(sample.arg(f.family()).arg(f.pointSize()));

--- a/src/fontdialog.h
+++ b/src/fontdialog.h
@@ -32,7 +32,8 @@ public:
     QFont getFont();
 
 private slots:
-    void setFontSample();
+    void setFontSample(const QFont &f);
+    void setFontSize();
 
 };
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -85,15 +85,15 @@ MainWindow::MainWindow(TerminalConfig &cfg,
     bookmarksWidget->setAutoFillBackground(true);
     m_bookmarksDock->setWidget(bookmarksWidget);
     addDockWidget(Qt::LeftDockWidgetArea, m_bookmarksDock);
-    connect(bookmarksWidget, SIGNAL(callCommand(QString)),
-            this, SLOT(bookmarksWidget_callCommand(QString)));
+    connect(bookmarksWidget, &BookmarksWidget::callCommand,
+            this, &MainWindow::bookmarksWidget_callCommand);
 
-    connect(m_bookmarksDock, SIGNAL(visibilityChanged(bool)),
-            this, SLOT(bookmarksDock_visibilityChanged(bool)));
+    connect(m_bookmarksDock, &QDockWidget::visibilityChanged,
+            this, &MainWindow::bookmarksDock_visibilityChanged);
 
-    connect(actAbout, SIGNAL(triggered()), SLOT(actAbout_triggered()));
-    connect(actAboutQt, SIGNAL(triggered()), qApp, SLOT(aboutQt()));
-    connect(&m_dropShortcut, SIGNAL(activated()), SLOT(showHide()));
+    connect(actAbout, &QAction::triggered, this, &MainWindow::actAbout_triggered);
+    connect(actAboutQt, &QAction::triggered, qApp, &QApplication::aboutQt);
+    connect(&m_dropShortcut, &QxtGlobalShortcut::activated, this, &MainWindow::showHide);
 
     setContentsMargins(0, 0, 0, 0);
     if (m_dropMode) {
@@ -111,7 +111,7 @@ MainWindow::MainWindow(TerminalConfig &cfg,
     }
 
     consoleTabulator->setAutoFillBackground(true);
-    connect(consoleTabulator, SIGNAL(closeTabNotification(bool)), SLOT(testClose(bool)));
+    connect(consoleTabulator, &TabWidget::closeTabNotification, this, &MainWindow::testClose);
     consoleTabulator->setTabPosition((QTabWidget::TabPosition)Properties::Instance()->tabsPos);
     //consoleTabulator->setShellProgram(command);
 
@@ -121,7 +121,7 @@ MainWindow::MainWindow(TerminalConfig &cfg,
     setupCustomDirs();
 
     connect(consoleTabulator, &TabWidget::currentTitleChanged, this, &MainWindow::onCurrentTitleChanged);
-    connect(menu_Actions, SIGNAL(aboutToShow()), this, SLOT(updateDisabledActions()));
+    connect(menu_Actions, &QMenu::aboutToShow, this, &MainWindow::updateDisabledActions);
 
     /* The tab should be added after all changes are made to
        the main window; otherwise, the initial prompt might
@@ -154,7 +154,7 @@ void MainWindow::enableDropMode()
     m_dropLockButton = new QToolButton(this);
     consoleTabulator->setCornerWidget(m_dropLockButton, Qt::BottomRightCorner);
     m_dropLockButton->setCheckable(true);
-    m_dropLockButton->connect(m_dropLockButton, SIGNAL(clicked(bool)), this, SLOT(setKeepOpen(bool)));
+    m_dropLockButton->connect(m_dropLockButton, &QToolButton::clicked, this, &MainWindow::setKeepOpen);
     setKeepOpen(Properties::Instance()->dropKeepOpen);
     m_dropLockButton->setAutoRaise(true);
 
@@ -397,8 +397,8 @@ void MainWindow::setup_ViewMenu_Actions()
     if( tabPosition->actions().count() > Properties::Instance()->tabsPos )
         tabPosition->actions().at(Properties::Instance()->tabsPos)->setChecked(true);
 
-    connect(tabPosition, SIGNAL(triggered(QAction *)),
-             consoleTabulator, SLOT(changeTabPosition(QAction *)) );
+    connect(tabPosition, &QActionGroup::triggered,
+             consoleTabulator, &TabWidget::changeTabPosition);
 
     if (tabPosMenu == NULL) {
         tabPosMenu = new QMenu(tr("&Tabs Layout"), menu_Window);
@@ -408,8 +408,8 @@ void MainWindow::setup_ViewMenu_Actions()
             tabPosMenu->addAction(tabPosition->actions().at(i));
         }
 
-        connect(menu_Window, SIGNAL(hovered(QAction *)),
-                this, SLOT(updateActionGroup(QAction *)));
+        connect(menu_Window, &QMenu::hovered,
+                this, &MainWindow::updateActionGroup);
     }
     menu_Window->addMenu(tabPosMenu);
     /* */
@@ -430,8 +430,8 @@ void MainWindow::setup_ViewMenu_Actions()
 
         if( Properties::Instance()->scrollBarPos < scrollBarPosition->actions().size() )
             scrollBarPosition->actions().at(Properties::Instance()->scrollBarPos)->setChecked(true);
-        connect(scrollBarPosition, SIGNAL(triggered(QAction *)),
-             consoleTabulator, SLOT(changeScrollPosition(QAction *)) );
+        connect(scrollBarPosition, &QActionGroup::triggered,
+             consoleTabulator, &TabWidget::changeScrollPosition);
 
     }
     if (scrollPosMenu == NULL) {
@@ -462,8 +462,8 @@ void MainWindow::setup_ViewMenu_Actions()
         if( Properties::Instance()->keyboardCursorShape < keyboardCursorShape->actions().size() )
             keyboardCursorShape->actions().at(Properties::Instance()->keyboardCursorShape)->setChecked(true);
 
-        connect(keyboardCursorShape, SIGNAL(triggered(QAction *)),
-                 consoleTabulator, SLOT(changeKeyboardCursorShape(QAction *)) );
+        connect(keyboardCursorShape, &QActionGroup::triggered,
+                 consoleTabulator, &TabWidget::changeKeyboardCursorShape);
     }
 
     if (keyboardCursorShapeMenu == NULL) {
@@ -564,8 +564,8 @@ void MainWindow::closeEvent(QCloseEvent *ev)
     QDialogButtonBox * buttonBox = new QDialogButtonBox(QDialogButtonBox::Yes | QDialogButtonBox::No, Qt::Horizontal, dia);
     buttonBox->button(QDialogButtonBox::Yes)->setDefault(true);
 
-    connect(buttonBox, SIGNAL(accepted()), dia, SLOT(accept()));
-    connect(buttonBox, SIGNAL(rejected()), dia, SLOT(reject()));
+    connect(buttonBox, &QDialogButtonBox::accepted, dia, &QDialog::accept);
+    connect(buttonBox, &QDialogButtonBox::rejected, dia, &QDialog::reject);
 
     QVBoxLayout * lay = new QVBoxLayout();
     lay->addWidget(new QLabel(tr("Are you sure you want to exit?")));
@@ -605,7 +605,7 @@ void MainWindow::actAbout_triggered()
 void MainWindow::actProperties_triggered()
 {
     PropertiesDialog *p = new PropertiesDialog(this);
-    connect(p, SIGNAL(propertiesChanged()), this, SLOT(propertiesChanged()));
+    connect(p, &PropertiesDialog::propertiesChanged, this, &MainWindow::propertiesChanged);
     p->exec();
 }
 

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -34,10 +34,10 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
 {
     setupUi(this);
 
-    connect(buttonBox->button(QDialogButtonBox::Apply), SIGNAL(clicked()),
-            this, SLOT(apply()));
-    connect(changeFontButton, SIGNAL(clicked()),
-            this, SLOT(changeFontButton_clicked()));
+    connect(buttonBox->button(QDialogButtonBox::Apply), &QPushButton::clicked,
+            this, &PropertiesDialog::apply);
+    connect(changeFontButton, &QPushButton::clicked,
+            this, &PropertiesDialog::changeFontButton_clicked);
     connect(chooseBackgroundImageButton, &QPushButton::clicked,
             this, &PropertiesDialog::chooseBackgroundImageButton_clicked);
 
@@ -137,8 +137,8 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
     useBookmarksCheckBox->setChecked(Properties::Instance()->useBookmarks);
     bookmarksLineEdit->setText(Properties::Instance()->bookmarksFile);
     openBookmarksFile(Properties::Instance()->bookmarksFile);
-    connect(bookmarksButton, SIGNAL(clicked()),
-            this, SLOT(bookmarksButton_clicked()));
+    connect(bookmarksButton, &QPushButton::clicked,
+            this, &PropertiesDialog::bookmarksButton_clicked);
 
     terminalPresetComboBox->setCurrentIndex(Properties::Instance()->terminalsPreset);
 

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -56,9 +56,9 @@ TabWidget::TabWidget(QWidget* parent) : QTabWidget(parent), tabNumerator(0), mTa
 
     tabBar()->installEventFilter(this);
 
-    connect(this, SIGNAL(tabCloseRequested(int)), this, SLOT(removeTab(int)));
-    connect(tabBar(), SIGNAL(tabMoved(int,int)), this, SLOT(updateTabIndices()));
-    connect(this, SIGNAL(tabRenameRequested(int)), this, SLOT(renameSession(int)));
+    connect(this, &TabWidget::tabCloseRequested, this, &TabWidget::removeTab);
+    connect(tabBar(), &QTabBar::tabMoved, this, &TabWidget::updateTabIndices);
+    connect(this, &TabWidget::tabRenameRequested, this, &TabWidget::renameSession);
     connect(this, &TabWidget::tabTitleColorChangeRequested, this, &TabWidget::setTitleColor);
 }
 
@@ -79,8 +79,8 @@ int TabWidget::addNewTab(TerminalConfig config)
 
     TermWidgetHolder *console = new TermWidgetHolder(config, this);
     console->setWindowTitle(label);
-    connect(console, SIGNAL(finished()), SLOT(removeFinished()));
-    connect(console, SIGNAL(lastTerminalClosed()), this, SLOT(removeFinished()));
+    connect(console, &TermWidgetHolder::finished, this, &TabWidget::removeFinished);
+    connect(console, &TermWidgetHolder::lastTerminalClosed, this, &TabWidget::removeFinished);
     connect(console, &TermWidgetHolder::termTitleChanged, this, &TabWidget::onTermTitleChanged);
     connect(this, &QTabWidget::currentChanged, this, &TabWidget::currentTitleChanged);
 

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -72,8 +72,8 @@ TermWidgetImpl::TermWidgetImpl(TerminalConfig &cfg, QWidget * parent)
     setMotionAfterPasting(Properties::Instance()->m_motionAfterPaste);
 
     setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(this, SIGNAL(customContextMenuRequested(const QPoint &)),
-            this, SLOT(customContextMenuCall(const QPoint &)));
+    connect(this, &QWidget::customContextMenuRequested,
+            this, &TermWidgetImpl::customContextMenuCall);
 
     connect(this, &QTermWidget::urlActivated, this, &TermWidgetImpl::activateUrl);
 
@@ -296,9 +296,9 @@ TermWidget::TermWidget(TerminalConfig &cfg, QWidget * parent)
 
     propertiesChanged();
 
-    connect(m_term, SIGNAL(finished()), this, SIGNAL(finished()));
-    connect(m_term, SIGNAL(termGetFocus()), this, SLOT(term_termGetFocus()));
-    connect(m_term, SIGNAL(termLostFocus()), this, SLOT(term_termLostFocus()));
+    connect(m_term, &QTermWidget::finished, this, &TermWidget::finished);
+    connect(m_term, &QTermWidget::termGetFocus, this, &TermWidget::term_termGetFocus);
+    connect(m_term, &QTermWidget::termLostFocus, this, &TermWidget::term_termLostFocus);
     connect(m_term, &QTermWidget::titleChanged, this, [this] { emit termTitleChanged(m_term->title(), m_term->icon()); });
 }
 

--- a/src/termwidgetholder.cpp
+++ b/src/termwidgetholder.cpp
@@ -360,19 +360,17 @@ TermWidget *TermWidgetHolder::newTerm(TerminalConfig &cfg)
 {
     TermWidget *w = new TermWidget(cfg, this);
     // proxy signals
-    connect(w, SIGNAL(renameSession()), this, SIGNAL(renameSession()));
-    connect(w, SIGNAL(removeCurrentSession()), this, SIGNAL(lastTerminalClosed()));
-    connect(w, SIGNAL(finished()), this, SLOT(handle_finished()));
+    connect(w, &TermWidget::renameSession, this, &TermWidgetHolder::renameSession);
+    connect(w, &TermWidget::removeCurrentSession, this, &TermWidgetHolder::lastTerminalClosed);
+    connect(w, &TermWidget::finished, this, &TermWidgetHolder::handle_finished);
     // consume signals
 
-    connect(w, SIGNAL(splitHorizontal(TermWidget *)),
-            this, SLOT(splitHorizontal(TermWidget *)));
-    connect(w, SIGNAL(splitVertical(TermWidget *)),
-            this, SLOT(splitVertical(TermWidget *)));
-    connect(w, SIGNAL(splitCollapse(TermWidget *)),
-            this, SLOT(splitCollapse(TermWidget *)));
-    connect(w, SIGNAL(termGetFocus(TermWidget *)),
-            this, SLOT(setCurrentTerminal(TermWidget *)));
+    connect(w, static_cast<void (TermWidget::*)(TermWidget *self)>(&TermWidget::splitHorizontal),
+            this, &TermWidgetHolder::splitHorizontal);
+    connect(w, static_cast<void (TermWidget::*)(TermWidget *self)>(&TermWidget::splitVertical),
+            this, &TermWidgetHolder::splitVertical);
+    connect(w, &TermWidget::splitCollapse, this, &TermWidgetHolder::splitCollapse);
+    connect(w, &TermWidget::termGetFocus, this, &TermWidgetHolder::setCurrentTerminal);
     connect(w, &TermWidget::termTitleChanged, this, &TermWidgetHolder::onTermTitleChanged);
 
     return w;


### PR DESCRIPTION
Convert connect calls that use the string-based syntax to the new one based on member pointer. Most of the conversions were straightforward, but there are some that are not:
* overloaded slots need to be explicitly cast, using static_cast, it looks ugly, the syntax used is from the qt wiki
* lambdas were converted to member functions
* inherited singals/slots must be typed to the base class
* signal and slot parameters must match, in simple cases dummy params were added, otherwise the static_cast would be needed
* implicit parameter values do not work anymore, but were used in some cases to keep the changes minimal where functions had no params and do not care

There's one conversion not done yet. It's in mainwindow.cpp, MainWindow::setup_Action. The slot name is passed as string. I did not succeed to convert that to the member pointer syntax with. The code could be refactored to avoid passing the slot as argument, but I'd rather get an ack before I do that.