### PR TITLE
Fix tabbar

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -549,7 +549,6 @@ void MainWindow::closeEvent(QCloseEvent *ev)
         Properties::Instance()->saveSettings();
         for (int i = consoleTabulator->count(); i > 0; --i) {
             consoleTabulator->removeTab(i - 1);
-            delete consoleTabulator->widget(i-1); //Also delete widget
         }
         ev->accept();
         return;
@@ -581,14 +580,13 @@ void MainWindow::closeEvent(QCloseEvent *ev)
         Properties::Instance()->saveSettings();
         for (int i = consoleTabulator->count(); i > 0; --i) {
             consoleTabulator->removeTab(i - 1);
-            delete consoleTabulator->widget(i-1);//Also delete widget
         }
         ev->accept();
     } else {
-
         if(m_removeFinished) {
+            QWidget *w = consoleTabulator->widget(consoleTabulator->count()-1);
             consoleTabulator->removeTab(consoleTabulator->count()-1);
-            delete consoleTabulator->widget(consoleTabulator->count()-1); //Also delete widget
+            delete w; // delete the widget because the window isn't closed
             m_removeFinished = false;
         }
         ev->ignore();

--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -24,8 +24,14 @@ TabBar::TabBar(QWidget *parent)
       mLimitWidth(false),
       mLimitWidthValue(0)
 {
+    // To make the selected tab text bold, first give a bold font to the tabbar
+    // for QStyle::sizeFromContents(QStyle::CT_TabBarTab, ...) to make room
+    // for the bold text, and then, set the non-selected tab text to normal.
+    QFont f = font();
+    f.setBold(true);
+    setFont(f);
+    setStyleSheet("QTabBar::tab:!selected { font-weight: normal; }");
     setStyle(new TabStyle(this));
-    setStyleSheet("QTabBar::tab:selected { font-weight: bold; }");
 }
 
 void TabBar::setLimitWidth(bool limitWidth)

--- a/src/tabstyle.cpp
+++ b/src/tabstyle.cpp
@@ -63,7 +63,7 @@ void TabStyle::drawControl(ControlElement element,
         // Draw the final text
         drawItemText(painter,
                      rect,
-                     Qt::AlignVCenter,
+                     Qt::AlignCenter,
                      tabOption->palette,
                      tabOption->state & State_Enabled,
                      elidedText,

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -50,7 +50,6 @@ TabWidget::TabWidget(QWidget* parent) : QTabWidget(parent), tabNumerator(0), mTa
 
     tabBar()->setUsesScrollButtons(true);
 
-    setTabsClosable(Properties::Instance()->showCloseTabButton);
     setMovable(true);
     setUsesScrollButtons(true);
 


### PR DESCRIPTION
Fixes https://github.com/lxde/qterminal/issues/395

The following issues are fixed:

(1) `Properties::Instance()->showCloseTabButton` shouldn't be used with `setTabsClosable()` in the c-tor of `TabWidget` because its value is not defined yet. This fixes the erratic behavior of tab close buttons.

(2) The tab pages shouldn't be deleted at `MainWindow::closeEvent()` -- except for one case -- because `TabWidget::removeTab()` deletes them; the last page is also deleted because it's a child of `TabWidget`.

(3) To make the slected tab text bold, we should give enough space to the tab by making the tabbar font bold and then, making the non-selected tab text normal.