### PR TITLE
Support modifying $TERM and use xterm-256color by default

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>864</width>
-    <height>728</height>
+    <width>952</width>
+    <height>947</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -494,7 +494,7 @@
             </property>
            </widget>
           </item>
-          <item row="9" column="1">
+          <item row="10" column="1">
            <spacer name="verticalSpacer_4">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -550,6 +550,33 @@
             <property name="text">
              <string>History size (in lines)</string>
             </property>
+           </widget>
+          </item>
+          <item row="9" column="0">
+           <widget class="QLabel" name="label_14">
+            <property name="text">
+             <string>Default $TERM</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="2">
+           <widget class="QComboBox" name="termComboBox">
+            <property name="editable">
+             <bool>true</bool>
+            </property>
+            <property name="currentIndex">
+             <number>1</number>
+            </property>
+            <item>
+             <property name="text">
+              <string>xterm</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>xterm-256color</string>
+             </property>
+            </item>
            </widget>
           </item>
          </layout>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -111,8 +111,6 @@ void parse_args(int argc, char* argv[], QString& workdir, QString & shell_comman
 
 int main(int argc, char *argv[])
 {
-    setenv("TERM", "xterm", 1); // TODO/FIXME: why?
-
     QApplication::setApplicationName("qterminal");
     QApplication::setApplicationVersion(STR_VERSION);
     QApplication::setOrganizationDomain("qterminal.org");
@@ -130,6 +128,11 @@ int main(int argc, char *argv[])
     QString workdir, shell_command;
     bool dropMode;
     parse_args(argc, argv, workdir, shell_command, dropMode);
+
+    Properties::Instance()->migrate_settings();
+    Properties::Instance()->loadSettings();
+
+    qputenv("TERM", Properties::Instance()->term.toLatin1());
 
     if (workdir.isEmpty())
         workdir = QDir::currentPath();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -75,8 +75,6 @@ MainWindow::MainWindow(TerminalConfig &cfg,
     setAttribute(Qt::WA_DeleteOnClose);
 
     setupUi(this);
-    Properties::Instance()->migrate_settings();
-    Properties::Instance()->loadSettings();
 
     m_bookmarksDock = new QDockWidget(tr("Bookmarks"), this);
     m_bookmarksDock->setObjectName("BookmarksDockWidget");

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -123,6 +123,7 @@ void Properties::loadSettings()
     saveSizeOnExit = m_settings->value("SaveSizeOnExit", true).toBool();
     savePosOnExit = m_settings->value("SavePosOnExit", true).toBool();
     useCWD = m_settings->value("UseCWD", false).toBool();
+    term = m_settings->value("Term", "xterm-256color").toString();
 
     // bookmarks
     useBookmarks = m_settings->value("UseBookmarks", false).toBool();
@@ -218,6 +219,7 @@ void Properties::saveSettings()
     m_settings->setValue("SavePosOnExit", savePosOnExit);
     m_settings->setValue("SaveSizeOnExit", saveSizeOnExit);
     m_settings->setValue("UseCWD", useCWD);
+    m_settings->setValue("Term", term);
 
     // bookmarks
     m_settings->setValue("UseBookmarks", useBookmarks);

--- a/src/properties.h
+++ b/src/properties.h
@@ -85,6 +85,8 @@ class Properties
 
         bool useCWD;
 
+        QString term;
+
         bool useBookmarks;
         bool bookmarksVisible;
         QString bookmarksFile;

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -150,6 +150,8 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
 
     useCwdCheckBox->setChecked(Properties::Instance()->useCWD);
 
+    termComboBox->setCurrentText(Properties::Instance()->term);
+
     historyLimited->setChecked(Properties::Instance()->historyLimited);
     historyUnlimited->setChecked(!Properties::Instance()->historyLimited);
     historyLimitedTo->setValue(Properties::Instance()->historyLimitedTo);
@@ -216,6 +218,8 @@ void PropertiesDialog::apply()
     Properties::Instance()->saveSizeOnExit = saveSizeOnExitCheckBox->isChecked();
 
     Properties::Instance()->useCWD = useCwdCheckBox->isChecked();
+
+    Properties::Instance()->term = termComboBox->currentText();
 
     Properties::Instance()->scrollBarPos = scrollBarPos_comboBox->currentIndex();
     Properties::Instance()->tabsPos = tabsPos_comboBox->currentIndex();


### PR DESCRIPTION
Fixes https://github.com/lxde/qterminal/issues/100
Closes https://github.com/lxde/qtermwidget/issues/12

Also, Properties is application-wise, not window-wise, so I moved it to main.cpp.

A screenshot:
![default](https://user-images.githubusercontent.com/1937689/36023855-d55dfbd4-0dc8-11e8-969c-795efa316f83.png)

I feel the UI design native. Feedbacks are welcomed.